### PR TITLE
Add support to focus a single test

### DIFF
--- a/docs/runnings-tests.md
+++ b/docs/runnings-tests.md
@@ -35,3 +35,20 @@ in yellow.
 
 > Note: A ignored test will not be evaluated, but the signature must be valid so
 > it needs to return an expectation.
+
+
+## Focusing tests
+
+If you only want to run a single (or a few) tests, you can substitute the `in`
+keyword with `focus`.
+
+```scala
+"test work in progress" focus:
+  expect(30 + 3).toEqual(33)
+```
+
+This will result in that _only_ focused tests are run, and all other tests are
+marked interpreted as ignored.
+
+> When in focued mode, SBT reporting will only print success or failure for tests
+> no ignored tests will be logged.

--- a/src/main/scala/intent/runner/TestSuiteRunner.scala
+++ b/src/main/scala/intent/runner/TestSuiteRunner.scala
@@ -62,6 +62,14 @@ class TestSuiteRunner(classLoader: ClassLoader) extends HotObservable[TestCaseRe
       case Success(instance) => runTestsForSuite(instance, eventSubscriber).map(res => Right(res))
       case Failure(ex: Throwable) => Future.successful(Left(TestSuiteError(ex)))
 
+  /**
+   * Instantiate the given test suite and evaluate which tests that should be run or ignored
+   */
+  private[intent] def evaluateSuite(className: String): Either[TestSuiteError, IntentStructure] =
+    instantiateSuite(className) match
+      case Success(instance) => Right(instance)
+      case Failure(ex: Throwable) => Left(TestSuiteError(ex))
+
   private def runTestsForSuite(suite: IntentStructure, eventSubscriber: Option[Subscriber[TestCaseResult]]) given(ec: ExecutionContext): Future[TestSuiteResult] =
     // TODO: We should measure Suite time as well. Might be good to find expensive setup or scheduling problems.
     val futureTestResults = suite.allTestCases.map(tc =>


### PR DESCRIPTION
Similar to `ignore` but more work in the SBT runner.

Runner needs to first instantiate each test and see if there is any focused test before actually starting to run test (since a non-focused might very well be the first test read).

This change should make it trivial to add support to focus on _context level_ as well (only toggle the `inFocusedMode` flag).

Increase the duplication in `internal.scala` =(