### PR TITLE
Remove "syntax" duplication

### DIFF
--- a/src/main/scala/intent/core/internal.scala
+++ b/src/main/scala/intent/core/internal.scala
@@ -59,7 +59,7 @@ trait IntentStateBase[TState] extends IntentStructure with TestLanguage:
   type Map = TState => TState
   type FlatMap = TState => Future[TState]
 
-  protected[intent] def isStateful: Boolean
+  private[intent] def isStateful: Boolean
 
   private[intent] sealed trait Context:
     def name: String
@@ -154,7 +154,7 @@ trait IntentStateBase[TState] extends IntentStructure with TestLanguage:
   * test cases act and assert on the state. 
   */
 trait IntentStateSyntax[TState] extends IntentStateBase[TState]:
-  protected[intent] override def isStateful = true
+  private[intent] override def isStateful = true
 
   def (context: String) using (init: => TState) given (pos: Position) : Context =
     ContextInit(context, () => Future.successful(init), pos)
@@ -186,7 +186,7 @@ trait IntentStateSyntax[TState] extends IntentStateBase[TState]:
   */
 trait IntentStatelessSyntax extends IntentStateBase[Unit]:
 
-  protected[intent] override def isStateful = false
+  private[intent] override def isStateful = false
 
   def (testName: String) in (testImpl: => Expectation) given (pos: Position): Unit =
     // When in focused mode, all "ordinary" tests becomes ignored
@@ -211,7 +211,7 @@ trait IntentStatelessSyntax extends IntentStateBase[Unit]:
 
 trait IntentAsyncStateSyntax[TState] extends IntentStateBase[TState]:
 
-  protected[intent] override def isStateful = true
+  private[intent] override def isStateful = true
 
   def (context: String) using (init: => TState) given (pos: Position): Context = ContextInit(context, () => Future.successful(init), pos)
   def (context: String) usingAsync (init: => Future[TState]) given (pos: Position): Context = ContextInit(context, () => init, pos)

--- a/src/main/scala/intent/core/internal.scala
+++ b/src/main/scala/intent/core/internal.scala
@@ -164,21 +164,17 @@ trait IntentStateSyntax[TState] extends IntentStateBase[TState]:
   def (ctx: Context) to (block: => Unit): Unit = withContext(ctx)(block)
 
   def (testName: String) in (testImpl: TState => Expectation) given (pos: Position): Unit =
-    // When in focused mode, all "ordinary" tests becomes ignored
-    val contexts = contextsInOrder
     if inFocusedMode then
-      addTestCase(IgnoredTestCase(contexts.map(_.name) :+ testName))
+      testName ignore testImpl
     else
-      addTestCase(TestCase(contexts, testName, testImpl, pos))
+      addTestCase(TestCase(contextsInOrder, testName, testImpl, pos))
 
   def (testName: String) ignore (testImpl: TState => Expectation): Unit =
-    val contexts = contextsInOrder
-    addTestCase(IgnoredTestCase(contexts.map(_.name) :+ testName))
+    addTestCase(IgnoredTestCase(contextsInOrder.map(_.name) :+ testName))
 
   def (testName: String) focus (testImpl: TState => Expectation) given (pos: Position): Unit =
     enableFocusedMode()
-    val contexts = contextsInOrder
-    addTestCase(TestCase(contexts, testName, testImpl, pos))
+    addTestCase(TestCase(contextsInOrder, testName, testImpl, pos))
 
 /**
   * Provides the Intent stateless test syntax, i.e. where contexts are merely structural
@@ -190,24 +186,21 @@ trait IntentStatelessSyntax extends IntentStateBase[Unit]:
 
   def (testName: String) in (testImpl: => Expectation) given (pos: Position): Unit =
     // When in focused mode, all "ordinary" tests becomes ignored
-    val contexts = contextsInOrder
     if inFocusedMode then
-      addTestCase(IgnoredTestCase(contexts.map(_.name) :+ testName))
+      testName ignore testImpl
     else
-      addTestCase(TestCase(contexts, testName, _ => testImpl, pos))
+      addTestCase(TestCase(contextsInOrder, testName, _ => testImpl, pos))
 
   def (blockName: String) apply (block: => Unit) given (pos: Position): Unit =
     val ctx = ContextInit(blockName, () => Future.successful(()), pos)
     withContext(ctx)(block)
 
   def (testName: String) ignore (testImpl: => Expectation): Unit =
-    val contexts = contextsInOrder
-    addTestCase(IgnoredTestCase(contexts.map(_.name) :+ testName))
+    addTestCase(IgnoredTestCase(contextsInOrder.map(_.name) :+ testName))
 
   def (testName: String) focus (testImpl: => Expectation) given (pos: Position): Unit =
     enableFocusedMode()
-    val contexts = contextsInOrder
-    addTestCase(TestCase(contexts, testName, _ => testImpl, pos))
+    addTestCase(TestCase(contextsInOrder, testName, _ => testImpl, pos))
 
 trait IntentAsyncStateSyntax[TState] extends IntentStateBase[TState]:
 
@@ -222,18 +215,14 @@ trait IntentAsyncStateSyntax[TState] extends IntentStateBase[TState]:
     withContext(ctx)(block)
 
   def (testName: String) in (testImpl: TState => Expectation) given (pos: Position): Unit =
-    // When in focused mode, all "ordinary" tests becomes ignored
-    val contexts = contextsInOrder
     if inFocusedMode then
-      addTestCase(IgnoredTestCase(contexts.map(_.name) :+ testName))
+      testName ignore testImpl
     else
-      addTestCase(TestCase(contexts, testName, testImpl, pos))
+      addTestCase(TestCase(contextsInOrder, testName, testImpl, pos))
 
   def (testName: String) ignore (testImpl: TState => Expectation): Unit =
-      val contexts = contextsInOrder
-      addTestCase(IgnoredTestCase(contexts.map(_.name) :+ testName))
+      addTestCase(IgnoredTestCase(contextsInOrder.map(_.name) :+ testName))
 
   def (testName: String) focus (testImpl: TState => Expectation) given (pos: Position): Unit =
     enableFocusedMode()
-    val contexts = contextsInOrder
-    addTestCase(TestCase(contexts, testName, testImpl, pos))
+    addTestCase(TestCase(contextsInOrder, testName, testImpl, pos))

--- a/src/main/scala/intent/core/internal.scala
+++ b/src/main/scala/intent/core/internal.scala
@@ -50,21 +50,32 @@ trait TestLanguage:
   // TODO: Can this be overridden? Or do we need a protected def
   given executionContext as ExecutionContext = ExecutionContext.global
 
-sealed trait IntentStateBase[TState] extends IntentStructure with TestLanguage:
-  type Transform = TState => TState
+/**
+  * Base structure for Intent test cases, whether they are async, sync, stateful or stateless.
+  * The structure is based on asynchronous execution, since it's possible to fit sync in async,
+  * but not vice versa.
+  */
+trait IntentStateBase[TState] extends IntentStructure with TestLanguage:
+  type Map = TState => TState
+  type FlatMap = TState => Future[TState]
 
   protected[intent] def isStateful: Boolean
 
   private[intent] sealed trait Context:
     def name: String
-    def transform(opt: Option[TState]): Option[TState]
+    def transform(f: Future[Option[TState]]): Future[Option[TState]]
     def position: Position
-  private[intent] case class ContextInit(name: String, init: () => TState, position: Position) extends Context:
-    def transform(opt: Option[TState]) = Some(init())
-  private[intent] case class ContextTx(name: String, tx: Transform, position: Position) extends Context:
-    def transform(opt: Option[TState]) = opt.map(tx)
+  private[intent] sealed case class ContextInit(name: String, init: () => Future[TState], position: Position) extends Context:
+    def transform(f: Future[Option[TState]]) = init().map(Some.apply)
+  private[intent] sealed case class ContextMap(name: String, tx: Map, position: Position) extends Context:
+    def transform(f: Future[Option[TState]]) = f.map(_.map(tx))
+  private[intent] sealed case class ContextFlatMap(name: String, tx: FlatMap, position: Position) extends Context:
+    def transform(f: Future[Option[TState]]) =
+      f.flatMap:
+        case Some(state) => tx(state).map(Some.apply)
+        case None        => throw ShouldNotHappenException("Unexpected state None after Future transform")
 
-  private[intent] case class TestCase(contexts: Seq[Context], name: String, impl: TState => Expectation, tcPosition: Position) extends ITestCase:
+  case class TestCase(contexts: Seq[Context], name: String, impl: TState => Expectation, tcPosition: Position) extends ITestCase:
     def nameParts: Seq[String] = contexts.map(_.name) :+ name
     def run(): Future[TestCaseResult] =
       import PositionDescription._
@@ -82,24 +93,25 @@ sealed trait IntentStateBase[TState] extends IntentStructure with TestLanguage:
         result(msg, ex, pos, TestFailed.apply)
 
       if isStateful && contexts.size == 0 then
-       return Future.successful(error("Top-level test cases are not allowed in a state-based test suite", None, tcPosition))
+        return Future.successful(error("Top-level test cases are not allowed in a state-based test suite", None, tcPosition))
 
-      // Execute the contexts. If a transformation results in None, something is seriously wrong
-      // so treat as error. If an exception is thrown, treat as test failure (since we have started
-      // to execute the test - state setup is part of the test).
-      val postSetup = contexts.foldLeft[Either[TestCaseResult, Option[TState]]](Right(None))((acc, ctx) => acc.flatMap {
-        stateOpt =>
+      val postSetup = contexts.foldLeft(Future.successful[Either[TestCaseResult, Option[TState]]](Right(None)))((fut, ctx) => fut.flatMap {
+        case l@Left(_) => Future.successful(l)
+        case Right(stateOpt) =>
           try
-            ctx.transform(stateOpt) match
-              case s@Some(_) => Right(s)
-              case None =>
-                Left(error(s"""Unexpected: state folding for context \"${ctx.name}\" didn't produce a state""", None, ctx.position))
+            ctx.transform(Future.successful(stateOpt)).transform :
+              case Success(newStateOpt) => Success(Right(newStateOpt))
+              case Failure(t: ShouldNotHappenException) =>
+                Success(Left(error(s"""${t.getMessage} for context \"${ctx.name}\"""", None, ctx.position)))
+              case Failure(t) =>
+                Success(Left(failure(s"""The state setup for context \"${ctx.name}\" failed""", Some(t), ctx.position)))
           catch
             case NonFatal(t) =>
-              Left(failure(s"""The state setup for context \"${ctx.name}\" failed""", Some(t), ctx.position))
+              // Should not happen since we control our Context classes
+              Future.successful(Left(error(s"""The transformation for context \"${ctx.name}\" failed""", Some(t), ctx.position)))
       })
 
-      postSetup match
+      postSetup.flatMap :
         case Left(r) => Future.successful(r)
         case Right(opt) =>
           try
@@ -112,7 +124,7 @@ sealed trait IntentStateBase[TState] extends IntentStructure with TestLanguage:
             }
           catch
             case NonFatal(t) =>
-              Future.successful(failure("Test failure", Some(t), tcPosition))
+              Future.successful(failure("Test error", Some(t), tcPosition))
 
   private[intent] override def allTestCases: Seq[ITestCase] = testCases
   private[intent] override def isFocused: Boolean = inFocusedMode
@@ -130,16 +142,18 @@ sealed trait IntentStateBase[TState] extends IntentStructure with TestLanguage:
   private var reverseContextStack: Seq[Context] = Seq.empty
   protected var inFocusedMode: Boolean = false
 
+
 /**
   * Provides the Intent stateful test syntax, i.e. where contexts arrange state and
   * test cases act and assert on the state. 
   */
 trait IntentStateSyntax[TState] extends IntentStateBase[TState]:
-
   protected[intent] override def isStateful = true
 
-  def (context: String) using (init: => TState) given (pos: Position) : Context = ContextInit(context, () => init, pos)
-  def (context: String) using (tx: Transform) given (pos: Position) : Context = ContextTx(context, tx, pos)
+  def (context: String) using (init: => TState) given (pos: Position) : Context =
+    ContextInit(context, () => Future.successful(init), pos)
+  def (context: String) using (tx: Map) given (pos: Position) : Context =
+    ContextMap(context, tx, pos)
 
   def (ctx: Context) to (block: => Unit): Unit = withContext(ctx)(block)
 
@@ -182,7 +196,7 @@ trait IntentStatelessSyntax extends IntentStateBase[Unit]:
       addTestCase(TestCase(contexts, testName, _ => testImpl, pos))
 
   def (blockName: String) apply (block: => Unit) given (pos: Position): Unit =
-    val ctx = ContextInit(blockName, () => (), pos)
+    val ctx = ContextInit(blockName, () => Future.successful(()), pos)
     withContext(ctx)(block)
 
   def (testName: String) ignore (testImpl: => Expectation): Unit =
@@ -199,84 +213,9 @@ trait IntentStatelessSyntax extends IntentStateBase[Unit]:
     val contexts = contextsInOrder
     addTestCase(TestCase(contexts, testName, _ => testImpl, pos))
 
-// TODO: Remove duplication wrt IntentStateSyntax
-// TODO: It would be nice if we could just do 'extends IntentStateSyntax[Future[TState]]',
-// TODO: but futureState.flatMap in run below is special here.
-trait IntentAsyncStateSyntax[TState] extends IntentStructure with TestLanguage:
-  type Map = TState => TState
-  type FlatMap = TState => Future[TState]
+trait IntentAsyncStateSyntax[TState] extends IntentStateBase[TState]:
 
-  trait Context:
-    def name: String
-    def transform(f: Future[Option[TState]]): Future[Option[TState]]
-    def position: Position
-  case class ContextInit(name: String, init: () => Future[TState], position: Position) extends Context:
-    def transform(f: Future[Option[TState]]) = init().map(Some.apply)
-  case class ContextMap(name: String, tx: Map, position: Position) extends Context:
-    def transform(f: Future[Option[TState]]) = f.map(_.map(tx))
-  case class ContextFlatMap(name: String, tx: FlatMap, position: Position) extends Context:
-    def transform(f: Future[Option[TState]]) =
-      f.flatMap:
-        case Some(state) => tx(state).map(Some.apply)
-        case None        => throw ShouldNotHappenException("Unexpected state None after Future transform")
-
-  case class TestCase(contexts: Seq[Context], name: String, impl: TState => Expectation, tcPosition: Position) extends ITestCase:
-    def nameParts: Seq[String] = contexts.map(_.name) :+ name
-    def run(): Future[TestCaseResult] =
-      import PositionDescription._
-
-      val before = System.nanoTime
-      def result(msg: String, ex: Option[Throwable], pos: Position, er: (String, Option[Throwable]) => ExpectationResult): TestCaseResult =
-        val elapsed = (System.nanoTime - before).nanos
-        val result = er(pos.contextualize(msg), ex)
-        TestCaseResult(elapsed, nameParts, result)
-
-      def error(msg: String, ex: Option[Throwable], pos: Position): TestCaseResult =
-        result(msg, ex, pos, TestError.apply)
-
-      def failure(msg: String, ex: Option[Throwable], pos: Position): TestCaseResult =
-        result(msg, ex, pos, TestFailed.apply)
-
-      if contexts.size == 0 then
-        return Future.successful(error("Top-level test cases are not allowed in a state-based test suite", None, tcPosition))
-
-      val postSetup = contexts.foldLeft(Future.successful[Either[TestCaseResult, Option[TState]]](Right(None)))((fut, ctx) => fut.flatMap {
-        case l@Left(_) => Future.successful(l)
-        case Right(stateOpt) =>
-          try
-            ctx.transform(Future.successful(stateOpt)).transform :
-              case Success(newStateOpt) => Success(Right(newStateOpt))
-              case Failure(t: ShouldNotHappenException) =>
-                Success(Left(error(s"""${t.getMessage} for context \"${ctx.name}\"""", None, ctx.position)))
-              case Failure(t) =>
-                Success(Left(failure(s"""The state setup for context \"${ctx.name}\" failed""", Some(t), ctx.position)))
-          catch
-            case NonFatal(t) =>
-              // Should not happen since we control our Context classes
-              Future.successful(Left(error(s"""The transformation for context \"${ctx.name}\" failed""", Some(t), ctx.position)))
-      })
-
-      postSetup.flatMap :
-        case Left(r) => Future.successful(r)
-        case Right(Some(state)) =>
-          try
-            val expectation = impl(state)
-            expectation.evaluate().map { result =>
-              val elapsed = (System.nanoTime - before).nanos
-              TestCaseResult(elapsed, nameParts, result)
-            }
-          catch
-            case NonFatal(t) =>
-              Future.successful(failure("Test error", Some(t), tcPosition))
-
-        case _ => ??? // should not happen since we handle None above
-
-  private[intent] override def allTestCases: Seq[ITestCase] = testCases
-  private[intent] override def isFocused: Boolean = inFocusedMode
-
-  private var testCases: Seq[ITestCase] = Seq.empty
-  private var reverseContextStack: Seq[Context] = Seq.empty
-  private var inFocusedMode: Boolean = false
+  protected[intent] override def isStateful = true
 
   def (context: String) using (init: => TState) given (pos: Position): Context = ContextInit(context, () => Future.successful(init), pos)
   def (context: String) usingAsync (init: => Future[TState]) given (pos: Position): Context = ContextInit(context, () => init, pos)
@@ -284,28 +223,26 @@ trait IntentAsyncStateSyntax[TState] extends IntentStructure with TestLanguage:
   def (context: String) usingAsync (fmc: FlatMap) given (pos: Position): Context = ContextFlatMap(context, fmc, pos)
 
   def (ctx: Context) to (block: => Unit): Unit =
-    reverseContextStack +:= ctx
-    try block finally reverseContextStack = reverseContextStack.tail
+    withContext(ctx)(block)
 
   def (testName: String) in (testImpl: TState => Expectation) given (pos: Position): Unit =
     // When in focused mode, all "ordinary" tests becomes ignored
+    val contexts = contextsInOrder
     if inFocusedMode then
-      val contexts = reverseContextStack.reverse
-      testCases :+= IgnoredTestCase(contexts.map(_.name) :+ testName)
+      addTestCase(IgnoredTestCase(contexts.map(_.name) :+ testName))
     else
-      val contexts = reverseContextStack.reverse
-      testCases :+= TestCase(contexts, testName, testImpl, pos)
+      addTestCase(TestCase(contexts, testName, testImpl, pos))
 
   def (testName: String) ignore (testImpl: TState => Expectation): Unit =
-      val contexts = reverseContextStack.reverse
-      testCases :+= IgnoredTestCase(contexts.map(_.name) :+ testName)
+      val contexts = contextsInOrder
+      addTestCase(IgnoredTestCase(contexts.map(_.name) :+ testName))
 
   def (testName: String) focus (testImpl: TState => Expectation) given (pos: Position): Unit =
     // If this is the first focused test, any existing testCase was not focused,
     // and hence should be converted to ignored to ignored tests (without execution)
     if !inFocusedMode then
       inFocusedMode = true
-      testCases = testCases.map(existing => IgnoredTestCase(existing.nameParts))
+      rewriteTestCases(existing => IgnoredTestCase(existing.nameParts))
 
-    val contexts = reverseContextStack.reverse
-    testCases :+= TestCase(contexts, testName, testImpl, pos)
+    val contexts = contextsInOrder
+    addTestCase(TestCase(contexts, testName, testImpl, pos))


### PR DESCRIPTION
Remove duplication in internal.scala by letting all syntax traits extend a common async stateful state trait.

Had to add some infra (isStateful) to handle stateful and stateless differently, as well as an ugly cast hack.