### PR TITLE
Table-driven test lab/proposal

### DIFF
--- a/src/test/scala/intent/styles/TableDrivenTest.scala
+++ b/src/test/scala/intent/styles/TableDrivenTest.scala
@@ -1,0 +1,18 @@
+package intent.styles
+
+import intent._
+
+class TableDrivenTest extends TestSuite with State[TableState]:
+  "Table-driven test" usingTable (myTable) to :
+    "uses table data" focus :
+      s =>
+        expect(s.a + s.b).toEqual(s.sum)
+
+  def myTable: Seq[TableState] = Seq(
+    TableState(1, 2, 3),
+    TableState(2, 3, 5),
+    TableState(-1, -2, -3)
+  )
+
+case class TableState(a: Int, b: Int, sum: Int):
+  override def toString = s"$a + $b should be $sum"


### PR DESCRIPTION
Ref #11

Syntax:

```
class TableDrivenTest extends TestSuite with State[TableState]:
  "Table-driven test" usingTable (myTable) to :
    "uses table data" focus :
      s =>
        expect(s.a + s.b).toEqual(s.sum)
```

Output:

```
[info] [PASSED] intent.styles.TableDrivenTest >> Table-driven test: 1 + 2 should be 3 >> uses table data (40 ms)
[info] [PASSED] intent.styles.TableDrivenTest >> Table-driven test: 2 + 3 should be 5 >> uses table data (12 ms)
[info] [PASSED] intent.styles.TableDrivenTest >> Table-driven test: -1 + -2 should be -3 >> uses table data (11 ms)
```

Right now `usingTable` can only be used on the root level (or rather, using it anywhere else will remove the previous state, because we don't prevent "root-level state" below the root yet).

The implementation works by repeating the context. The drawback is that the test part ("uses table data" above) gets repeated, which is noisy.