### PR TITLE
Context level focus and ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Make it possible to focus on a hierarchy / tree of tests using `focused` instead of `to` on context level.
   See [Focusing tests](docs/running-tests.md#Focusing-tests) for more details.
 
+* Make it possible to ignore on a hierarchy / tree of tests using `ignored` instead of `to` on context level.
+  See [Focusing tests](docs/running-tests.md#Focusing-tests) for more details.
+
 ## 0.1.0 (2019-10-17)
 
 * Initial public release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Pending
+
+* Make it possible to focus on a  hierarchy / tree of tests using `focused` on context level.
+
 ## 0.1.0 (2019-10-17)
 
 * Initial public release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Pending
 
-* Make it possible to focus on a  hierarchy / tree of tests using `focused` on context level.
+* Make it possible to focus on a hierarchy / tree of tests using `focused` instead of `to` on context level.
+  See [Focusing tests](docs/running-tests.md#Focusing-tests) for more details.
 
 ## 0.1.0 (2019-10-17)
 

--- a/docs/running-tests.md
+++ b/docs/running-tests.md
@@ -47,6 +47,16 @@ keyword with `focus`.
   expect(30 + 3).toEqual(33)
 ```
 
+If you want to focus on a hierarchy of tests, just substitute `to` with `focused`
+
+E.g.:
+
+```scala
+"name" using (state) focused
+"name" usingTable(source) focused:
+"name" usingAsync(state) focused:
+```
+
 This will result in that _only_ focused tests are run, and all other tests are
 marked interpreted as ignored.
 

--- a/docs/running-tests.md
+++ b/docs/running-tests.md
@@ -26,6 +26,16 @@ If you want to ignore a test you can substitute the `in` keyword with `ignore`.
   fail("This should never fail, only be ignored!")
 ```
 
+If you want to ignore a hierarchy of tests, just substitute `to` with `ignored`
+
+E.g.:
+
+```scala
+"name" using (state) ignored:
+"name" usingTable(source) ignored:
+"name" usingAsync(state) ignored:
+```
+
 Ignored tests will still be logged by SBT, but classified as `IGNORED` and printed
 in yellow.
 
@@ -52,7 +62,7 @@ If you want to focus on a hierarchy of tests, just substitute `to` with `focused
 E.g.:
 
 ```scala
-"name" using (state) focused
+"name" using (state) focused:
 "name" usingTable(source) focused:
 "name" usingAsync(state) focused:
 ```

--- a/src/main/scala/intent/core/internal.scala
+++ b/src/main/scala/intent/core/internal.scala
@@ -294,7 +294,12 @@ trait IntentAsyncStateSyntax[TState] extends IntentStateBase[TState]:
   def (context: String) usingAsync (fmc: FlatMap) given (pos: Position): Context = ContextFlatMap(context, fmc, pos)
 
   def (ctx: Context) to (block: => Unit): Unit =
-    withContext(ctx)(block)
+    isParentFocused() match
+      case true => withContext(ctx.withFocus())(block)
+      case _ => withContext(ctx)(block)
+
+  def (ctx: Context) focused (block: => Unit): Unit =
+    withContext(ctx.withFocus())(block)
 
   def (testName: String) in (testImpl: TState => Expectation) given (pos: Position): Unit =
     if inFocusedMode && !isParentFocused() then

--- a/src/main/scala/intent/core/internal.scala
+++ b/src/main/scala/intent/core/internal.scala
@@ -245,7 +245,7 @@ trait IntentStateSyntax[TState] extends IntentStateBase[TState]:
       Future.failed(new ShouldNotHappenException("TableDriveContext should not be used directly"))
 
     override def expand(): Iterable[Context] =
-      generator().map(s => ContextInit(s"$name: $s", () => Future.successful(s), position))
+      generator().map(s => ContextInit(s"$name: $s", () => Future.successful(s), position, hasFocus = hasFocus))
 
     def withFocus() = this.copy(hasFocus = true)
 

--- a/src/test/scala/intent/runner/FocusedTest.scala
+++ b/src/test/scala/intent/runner/FocusedTest.scala
@@ -8,9 +8,7 @@ import intent.helpers.TestSuiteRunnerTester
 
 import scala.concurrent.{ExecutionContext, Future}
 
-
-class FocusedTestTwo extends TestSuite with State[FocusedTestCase]:
-  // TOOD: Move the other focus tests to this file
+class FocusedTest extends TestSuite with State[FocusedTestCase]:
   // TOOD: Test Async state
   // TOOD: Test focused table
 
@@ -45,6 +43,9 @@ class FocusedTestTwo extends TestSuite with State[FocusedTestCase]:
     FocusedTestCase("intent.runner.MidBranchFocusedStatelessTestSuite", expectedSuccessful = 3, expectedIgnored = 2),
     FocusedTestCase("intent.runner.NestedFocusedStatefulTestSuite", expectedSuccessful = 3, expectedIgnored = 2),
     FocusedTestCase("intent.runner.MidBranchFocusedStatefulTestSuite", expectedSuccessful = 3, expectedIgnored = 2),
+    FocusedTestCase("intent.runner.FocusedStatelessTestSuite", expectedSuccessful = 2, expectedIgnored = 1),
+    FocusedTestCase("intent.runner.FocusedStatefulTestSuite", expectedSuccessful = 2, expectedIgnored = 1),
+    FocusedTestCase("intent.runner.FocusedAsyncStatefulTestSuite", expectedSuccessful = 2, expectedIgnored = 1),
   )
 
 case class FocusedTestCase(suiteClassName: String = null, expectedSuccessful:Int = 0, expectedIgnored:Int = 0) given (ec: ExecutionContext) extends TestSuiteRunnerTester:
@@ -120,3 +121,26 @@ class MidBranchFocusedStatefulTestSuite extends State[Unit]:
     "a third suite" using (()) to:
       "should include single focus" focus:
         _ => success()
+
+class FocusedStatelessTestSuite extends Stateless:
+  "should not be run" in fail("Test is not expected to run!")
+  "should be run" focus success()
+  "should also be run" focus success()
+
+class FocusedStatefulTestSuite extends State[Unit]:
+  "with state" using (()) to:
+    "should not be run" in:
+      _ => fail("Test is not expected to run!")
+    "should be run" focus:
+      _ => success()
+    "should also be run" focus:
+      _ => success()
+
+class FocusedAsyncStatefulTestSuite extends AsyncState[Unit]:
+  "with state" usingAsync (Future.successful(())) to:
+    "should not be run" in:
+      _ => fail("Test is not expected to run!")
+    "should be run" focus:
+      _ => success()
+    "should also be run" focus:
+      _ => success()

--- a/src/test/scala/intent/runner/FocusedTest.scala
+++ b/src/test/scala/intent/runner/FocusedTest.scala
@@ -8,116 +8,46 @@ import intent.helpers.TestSuiteRunnerTester
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class FocusedTest extends TestSuite with State[FocusedTestCase]:
-  // TODO: Convert these tests to table driven tests
+
+class FocusedTestTwo extends TestSuite with State[FocusedTestCase]:
   // TOOD: Move the other focus tests to this file
+  // TOOD: Test Async state
+  // TOOD: Test focused table
 
-  "FocusedTest" using FocusedTestCase() to :
-    "running nested stateless" using (_.nestedStateless) to:
-      "should be focused" in:
-        state =>
-            expect(state.evaluate().isFocused).toEqual(true)
+  "FocusedTest" usingTable (focusedSuites) to:
+    "should be focused" in:
+      state =>
+        expect(state.evaluate().isFocused).toEqual(true)
 
-      "report that 2 tests were run" in:
-          state =>
-            whenComplete(state.runAll()):
-              possible => possible match
-                case Left(_) => fail("Unexpected Left")
-                case Right(result) => expect(result.successful).toEqual(4)
+    "report that correct number of tests were run" in:
+      state =>
+        whenComplete(state.runAll()):
+          possible => possible match
+            case Left(_) => fail("Unexpected Left")
+            case Right(result) => expect(result.successful).toEqual(state.expectedSuccessful)
 
-      "report that 2 test were ignored" in:
-        state =>
-          whenComplete(state.runAll()):
-            possible => possible match
-              case Left(_) => fail("Unexpected Left")
-              case Right(result) => expect(result.ignored).toEqual(2)
+    "report that correct number test were ignored" in:
+      state =>
+        whenComplete(state.runAll()):
+          possible => possible match
+            case Left(_) => fail("Unexpected Left")
+            case Right(result) => expect(result.ignored).toEqual(state.expectedIgnored)
 
-      "no tests should be failed" in:
-        state =>
-          whenComplete(state.runAll()):
-            possible => possible match
-              case Left(_) => fail("Unexpected Left")
-              case Right(result) => expect(result.failed).toEqual(0)
+    "no tests should be failed" in:
+      state =>
+        whenComplete(state.runAll()):
+          possible => possible match
+            case Left(_) => fail("Unexpected Left")
+            case Right(result) => expect(result.failed).toEqual(0)
 
-    "running mid-branch stateless" using (_.midBranchStateless) to :
-      "should be focused" in:
-        state =>
-            expect(state.evaluate().isFocused).toEqual(true)
+  def focusedSuites = Seq(
+    FocusedTestCase("intent.runner.NestedFocusedStatelessTestSuite", expectedSuccessful = 4, expectedIgnored = 2),
+    FocusedTestCase("intent.runner.MidBranchFocusedStatelessTestSuite", expectedSuccessful = 3, expectedIgnored = 2),
+    FocusedTestCase("intent.runner.NestedFocusedStatefulTestSuite", expectedSuccessful = 3, expectedIgnored = 2),
+    FocusedTestCase("intent.runner.MidBranchFocusedStatefulTestSuite", expectedSuccessful = 3, expectedIgnored = 2),
+  )
 
-      "report that 2 tests were run" in:
-          state =>
-            whenComplete(state.runAll()):
-              possible => possible match
-                case Left(_) => fail("Unexpected Left")
-                case Right(result) => expect(result.successful).toEqual(3)
-
-      "report that 2 test were ignored" in:
-        state =>
-          whenComplete(state.runAll()):
-            possible => possible match
-              case Left(_) => fail("Unexpected Left")
-              case Right(result) => expect(result.ignored).toEqual(2)
-
-      "no tests should be failed" in:
-        state =>
-          whenComplete(state.runAll()):
-            possible => possible match
-              case Left(_) => fail("Unexpected Left")
-              case Right(result) => expect(result.failed).toEqual(0)
-
-    "running nested stateful" using (_.nestedStateful) to:
-      "should be focused" in:
-        state =>
-            expect(state.evaluate().isFocused).toEqual(true)
-
-      "report that 2 tests were run" in:
-          state =>
-            whenComplete(state.runAll()):
-              possible => possible match
-                case Left(_) => fail("Unexpected Left")
-                case Right(result) => expect(result.successful).toEqual(3)
-
-      "report that 2 test were ignored" in:
-        state =>
-          whenComplete(state.runAll()):
-            possible => possible match
-              case Left(_) => fail("Unexpected Left")
-              case Right(result) => expect(result.ignored).toEqual(2)
-
-      "no tests should be failed" in:
-        state =>
-          whenComplete(state.runAll()):
-            possible => possible match
-              case Left(_) => fail("Unexpected Left")
-              case Right(result) => expect(result.failed).toEqual(0)
-
-    "running mid-branch stateful" using (_.midBranchStateful) to :
-      "should be focused" in:
-        state =>
-          expect(state.evaluate().isFocused).toEqual(true)
-
-      "report that 2 tests were run" in:
-        state =>
-          whenComplete(state.runAll()):
-            possible => possible match
-              case Left(_) => fail("Unexpected Left")
-              case Right(result) => expect(result.successful).toEqual(3)
-
-      "report that 2 test were ignored" in:
-        state =>
-          whenComplete(state.runAll()):
-            possible => possible match
-              case Left(_) => fail("Unexpected Left")
-              case Right(result) => expect(result.ignored).toEqual(2)
-
-      "no tests should be failed" in:
-        state =>
-          whenComplete(state.runAll()):
-            possible => possible match
-              case Left(_) => fail("Unexpected Left")
-              case Right(result) => expect(result.failed).toEqual(0)
-
-case class FocusedTestCase(suiteClassName: String = null) given (ec: ExecutionContext) extends TestSuiteRunnerTester:
+case class FocusedTestCase(suiteClassName: String = null, expectedSuccessful:Int = 0, expectedIgnored:Int = 0) given (ec: ExecutionContext) extends TestSuiteRunnerTester:
   def nestedStateless       = FocusedTestCase("intent.runner.NestedFocusedStatelessTestSuite")
   def midBranchStateless    = FocusedTestCase("intent.runner.MidBranchFocusedStatelessTestSuite")
   def nestedStateful        = FocusedTestCase("intent.runner.NestedFocusedStatefulTestSuite")

--- a/src/test/scala/intent/runner/FocusedTest.scala
+++ b/src/test/scala/intent/runner/FocusedTest.scala
@@ -45,6 +45,8 @@ class FocusedTest extends TestSuite with State[FocusedTestCase]:
     FocusedTestCase("intent.runner.FocusedAsyncStatefulTestSuite", expectedSuccessful = 4, expectedIgnored = 1, focused = true),
     FocusedTestCase("intent.runner.FocusedTableDrivenTestSuite", expectedSuccessful = 4, expectedIgnored = 1, focused = true),
     FocusedTestCase("intent.runner.IgnoredStatelessTestSuite", expectedSuccessful = 1, expectedIgnored = 5, focused = false),
+    FocusedTestCase("intent.runner.IgnoredTableDrivenTestSuite", expectedSuccessful = 2, expectedIgnored = 3, focused = false),
+    FocusedTestCase("intent.runner.IgnoredStatefulTestSuite", expectedSuccessful = 1, expectedIgnored = 3, focused = false),
   )
 
 case class FocusedTestCase(
@@ -176,3 +178,34 @@ class IgnoredStatelessTestSuite extends Stateless:
         "should not be run" in fail("should not happen")
         "should also not be run" in fail("should not happen")
     "should be run" in success()
+
+class IgnoredTableDrivenTestSuite extends State[Unit]:
+  "top level" using (()) to:
+    "nested level" using (()) to:
+      "should be run" in:
+        _ => success()
+
+  "another suite" using (()) to:
+    "that use a table" usingTable(tableTests) ignored:
+      "should *not* be run" in:
+        _ => fail("should not happen")
+    "should be run" in:
+      _ => success()
+
+  def tableTests = Seq((), (), ())
+
+class IgnoredStatefulTestSuite extends State[Unit]:
+  "some suite" using (()) ignored:
+    "nested suite" using (()) to:
+      "should not be run" in:
+        _ => fail("should not happen")
+    "nested focus has lower prio" using (()) focused:
+      "should not be run" in:
+          _ => fail("should not happen")
+
+    "should also not be run" in:
+        _ => fail("should not happen")
+
+  "another suite" using (()) to:
+    "should be run" in:
+      _ => success()

--- a/src/test/scala/intent/runner/FocusedTest.scala
+++ b/src/test/scala/intent/runner/FocusedTest.scala
@@ -9,7 +9,7 @@ import intent.helpers.TestSuiteRunnerTester
 import scala.concurrent.{ExecutionContext, Future}
 
 class FocusedTest extends TestSuite with State[FocusedTestCase]:
-  "FocusedTest" usingTable (focusedSuites) focused:
+  "FocusedTest" usingTable (focusedSuites) to:
     "should be focused" in:
       state =>
         expect(state.evaluate().isFocused).toEqual(state.focused)

--- a/src/test/scala/intent/runner/FocusedTest.scala
+++ b/src/test/scala/intent/runner/FocusedTest.scala
@@ -9,8 +9,6 @@ import intent.helpers.TestSuiteRunnerTester
 import scala.concurrent.{ExecutionContext, Future}
 
 class FocusedTest extends TestSuite with State[FocusedTestCase]:
-  // TOOD: Test Async state
-
   "FocusedTest" usingTable (focusedSuites) to:
     "should be focused" in:
       state =>
@@ -44,7 +42,7 @@ class FocusedTest extends TestSuite with State[FocusedTestCase]:
     FocusedTestCase("intent.runner.MidBranchFocusedStatefulTestSuite", expectedSuccessful = 3, expectedIgnored = 2),
     FocusedTestCase("intent.runner.FocusedStatelessTestSuite", expectedSuccessful = 2, expectedIgnored = 1),
     FocusedTestCase("intent.runner.FocusedStatefulTestSuite", expectedSuccessful = 2, expectedIgnored = 1),
-    FocusedTestCase("intent.runner.FocusedAsyncStatefulTestSuite", expectedSuccessful = 2, expectedIgnored = 1),
+    FocusedTestCase("intent.runner.FocusedAsyncStatefulTestSuite", expectedSuccessful = 4, expectedIgnored = 1),
     FocusedTestCase("intent.runner.FocusedTableDrivenTestSuite", expectedSuccessful = 4, expectedIgnored = 1)
   )
 
@@ -155,3 +153,10 @@ class FocusedAsyncStatefulTestSuite extends AsyncState[Unit]:
       _ => success()
     "should also be run" focus:
       _ => success()
+
+  "sibling" usingAsync (Future.successful(())) focused:
+    "sibling child" usingAsync (Future.successful(())) to:
+      "should be run" in:
+         _ => success()
+    "should be run" in:
+       _ => success()

--- a/src/test/scala/intent/runner/FocusedTest.scala
+++ b/src/test/scala/intent/runner/FocusedTest.scala
@@ -1,0 +1,192 @@
+package intent.runner
+
+import intent.{TestSuite, State, Stateless, AsyncState}
+import intent.core.{Expectation, ExpectationResult, TestError, TestFailed, Subscriber, TestCaseResult, IntentStructure}
+import intent.runner.{TestSuiteRunner, TestSuiteError, TestSuiteResult}
+import intent.testdata._
+import intent.helpers.TestSuiteRunnerTester
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class FocusedTest extends TestSuite with State[FocusedTestCase]:
+  // TODO: Convert these tests to table driven tests
+  // TOOD: Move the other focus tests to this file
+
+  "FocusedTest" using FocusedTestCase() to :
+    "running nested stateless" using (_.nestedStateless) to:
+      "should be focused" in:
+        state =>
+            expect(state.evaluate().isFocused).toEqual(true)
+
+      "report that 2 tests were run" in:
+          state =>
+            whenComplete(state.runAll()):
+              possible => possible match
+                case Left(_) => fail("Unexpected Left")
+                case Right(result) => expect(result.successful).toEqual(4)
+
+      "report that 2 test were ignored" in:
+        state =>
+          whenComplete(state.runAll()):
+            possible => possible match
+              case Left(_) => fail("Unexpected Left")
+              case Right(result) => expect(result.ignored).toEqual(2)
+
+      "no tests should be failed" in:
+        state =>
+          whenComplete(state.runAll()):
+            possible => possible match
+              case Left(_) => fail("Unexpected Left")
+              case Right(result) => expect(result.failed).toEqual(0)
+
+    "running mid-branch stateless" using (_.midBranchStateless) to :
+      "should be focused" in:
+        state =>
+            expect(state.evaluate().isFocused).toEqual(true)
+
+      "report that 2 tests were run" in:
+          state =>
+            whenComplete(state.runAll()):
+              possible => possible match
+                case Left(_) => fail("Unexpected Left")
+                case Right(result) => expect(result.successful).toEqual(3)
+
+      "report that 2 test were ignored" in:
+        state =>
+          whenComplete(state.runAll()):
+            possible => possible match
+              case Left(_) => fail("Unexpected Left")
+              case Right(result) => expect(result.ignored).toEqual(2)
+
+      "no tests should be failed" in:
+        state =>
+          whenComplete(state.runAll()):
+            possible => possible match
+              case Left(_) => fail("Unexpected Left")
+              case Right(result) => expect(result.failed).toEqual(0)
+
+    "running nested stateful" using (_.nestedStateful) to:
+      "should be focused" in:
+        state =>
+            expect(state.evaluate().isFocused).toEqual(true)
+
+      "report that 2 tests were run" in:
+          state =>
+            whenComplete(state.runAll()):
+              possible => possible match
+                case Left(_) => fail("Unexpected Left")
+                case Right(result) => expect(result.successful).toEqual(3)
+
+      "report that 2 test were ignored" in:
+        state =>
+          whenComplete(state.runAll()):
+            possible => possible match
+              case Left(_) => fail("Unexpected Left")
+              case Right(result) => expect(result.ignored).toEqual(2)
+
+      "no tests should be failed" in:
+        state =>
+          whenComplete(state.runAll()):
+            possible => possible match
+              case Left(_) => fail("Unexpected Left")
+              case Right(result) => expect(result.failed).toEqual(0)
+
+    "running mid-branch stateful" using (_.midBranchStateful) to :
+      "should be focused" in:
+        state =>
+          expect(state.evaluate().isFocused).toEqual(true)
+
+      "report that 2 tests were run" in:
+        state =>
+          whenComplete(state.runAll()):
+            possible => possible match
+              case Left(_) => fail("Unexpected Left")
+              case Right(result) => expect(result.successful).toEqual(3)
+
+      "report that 2 test were ignored" in:
+        state =>
+          whenComplete(state.runAll()):
+            possible => possible match
+              case Left(_) => fail("Unexpected Left")
+              case Right(result) => expect(result.ignored).toEqual(2)
+
+      "no tests should be failed" in:
+        state =>
+          whenComplete(state.runAll()):
+            possible => possible match
+              case Left(_) => fail("Unexpected Left")
+              case Right(result) => expect(result.failed).toEqual(0)
+
+case class FocusedTestCase(suiteClassName: String = null) given (ec: ExecutionContext) extends TestSuiteRunnerTester:
+  def nestedStateless       = FocusedTestCase("intent.runner.NestedFocusedStatelessTestSuite")
+  def midBranchStateless    = FocusedTestCase("intent.runner.MidBranchFocusedStatelessTestSuite")
+  def nestedStateful        = FocusedTestCase("intent.runner.NestedFocusedStatefulTestSuite")
+  def midBranchStateful     = FocusedTestCase("intent.runner.MidBranchFocusedStatefulTestSuite")
+
+class NestedFocusedStatelessTestSuite extends Stateless:
+  "some suite" focused:
+    "nested suite":
+      "should be run" in success()
+      "should also be run" in success()
+
+  "another suite":
+    "should *not* be run" in fail("should not happen")
+
+  "a third suite":
+    "should include single focus" focus success()
+
+  "should also *not* be run" in fail("should not happen")
+  "should be run" focus success()
+
+class MidBranchFocusedStatelessTestSuite extends Stateless:
+  "some suite":
+    "another suite":
+      "should *not* be run A" in fail("should not happen")
+      "should also *not* be run B" in fail("should not happen")
+
+    "nested suite" focused:
+      "should be run C" in success()
+      "should also be run D" in success()
+
+    "a third suite":
+      "should include single focus" focus success()
+
+class NestedFocusedStatefulTestSuite extends State[Unit]:
+  "focused suite" using (()) focused:
+    "nested suite" using (()) to:
+      "should be run 1" in:
+        _ => success()
+
+      "should also be run 2" in:
+         _ => success()
+
+  "another suite" using (()) to:
+    "should *not* be run 3" in:
+      _ => fail("should not happen")
+
+  "should also *not* be run 4" in:
+    _ => fail("should not happen")
+
+  "a third suite" using (()) to:
+    "should include single focus" focus:
+      _ => success()
+
+class MidBranchFocusedStatefulTestSuite extends State[Unit]:
+  "some suite" using (()) to:
+    "another suite" using (()) to:
+      "should *not* be run" in:
+        _ => fail("should not happen")
+
+      "should also *not* be run 4" in:
+        _ => fail("should not happen")
+
+    "nested suite" using (()) focused:
+      "should be run" in:
+        _ => success()
+
+      "should also be run" in:
+        _ => success()
+
+    "a third suite" using (()) to:
+      "should include single focus" focus:
+        _ => success()

--- a/src/test/scala/intent/runner/FocusedTest.scala
+++ b/src/test/scala/intent/runner/FocusedTest.scala
@@ -10,7 +10,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class FocusedTest extends TestSuite with State[FocusedTestCase]:
   // TOOD: Test Async state
-  // TOOD: Test focused table
 
   "FocusedTest" usingTable (focusedSuites) to:
     "should be focused" in:
@@ -46,13 +45,10 @@ class FocusedTest extends TestSuite with State[FocusedTestCase]:
     FocusedTestCase("intent.runner.FocusedStatelessTestSuite", expectedSuccessful = 2, expectedIgnored = 1),
     FocusedTestCase("intent.runner.FocusedStatefulTestSuite", expectedSuccessful = 2, expectedIgnored = 1),
     FocusedTestCase("intent.runner.FocusedAsyncStatefulTestSuite", expectedSuccessful = 2, expectedIgnored = 1),
+    FocusedTestCase("intent.runner.FocusedTableDrivenTestSuite", expectedSuccessful = 4, expectedIgnored = 1)
   )
 
-case class FocusedTestCase(suiteClassName: String = null, expectedSuccessful:Int = 0, expectedIgnored:Int = 0) given (ec: ExecutionContext) extends TestSuiteRunnerTester:
-  def nestedStateless       = FocusedTestCase("intent.runner.NestedFocusedStatelessTestSuite")
-  def midBranchStateless    = FocusedTestCase("intent.runner.MidBranchFocusedStatelessTestSuite")
-  def nestedStateful        = FocusedTestCase("intent.runner.NestedFocusedStatefulTestSuite")
-  def midBranchStateful     = FocusedTestCase("intent.runner.MidBranchFocusedStatefulTestSuite")
+case class FocusedTestCase(suiteClassName: String = null, expectedSuccessful:Int = 0, expectedIgnored:Int = 0) given (ec: ExecutionContext) extends TestSuiteRunnerTester
 
 class NestedFocusedStatelessTestSuite extends Stateless:
   "some suite" focused:
@@ -121,6 +117,21 @@ class MidBranchFocusedStatefulTestSuite extends State[Unit]:
     "a third suite" using (()) to:
       "should include single focus" focus:
         _ => success()
+
+class FocusedTableDrivenTestSuite extends State[Unit]:
+  "top level" using (()) to:
+    "nested level" using (()) to:
+      "should not be run" in:
+        _ => fail("should not happen")
+    "should be run" focus:
+      _ => success()
+
+  "another suite" using (()) to:
+    "that use a table" usingTable(tableTests) focused:
+      "should be run" in:
+        _ => success()
+
+  def tableTests = Seq((), (), ())
 
 class FocusedStatelessTestSuite extends Stateless:
   "should not be run" in fail("Test is not expected to run!")

--- a/src/test/scala/intent/runner/FocusedTest.scala
+++ b/src/test/scala/intent/runner/FocusedTest.scala
@@ -47,6 +47,7 @@ class FocusedTest extends TestSuite with State[FocusedTestCase]:
     FocusedTestCase("intent.runner.IgnoredStatelessTestSuite", expectedSuccessful = 1, expectedIgnored = 5, focused = false),
     FocusedTestCase("intent.runner.IgnoredTableDrivenTestSuite", expectedSuccessful = 2, expectedIgnored = 3, focused = false),
     FocusedTestCase("intent.runner.IgnoredStatefulTestSuite", expectedSuccessful = 1, expectedIgnored = 3, focused = false),
+    FocusedTestCase("intent.runner.IgnoredAsyncStatefulTestSuite", expectedSuccessful = 2, expectedIgnored = 2, focused = false),
   )
 
 case class FocusedTestCase(
@@ -209,3 +210,17 @@ class IgnoredStatefulTestSuite extends State[Unit]:
   "another suite" using (()) to:
     "should be run" in:
       _ => success()
+
+class IgnoredAsyncStatefulTestSuite extends AsyncState[Unit]:
+  "with state" usingAsync (Future.successful(())) ignored:
+    "should not be run" in:
+      _ => fail("Test is not expected to run!")
+    "should be run" focus:
+      _ => fail("Test is not expected to run!")
+
+  "sibling" usingAsync (Future.successful(())) to:
+    "sibling child" usingAsync (Future.successful(())) to:
+      "should be run" in:
+         _ => success()
+    "should be run" in:
+       _ => success()

--- a/src/test/scala/intent/runner/TestSuiteRunnerTest.scala
+++ b/src/test/scala/intent/runner/TestSuiteRunnerTest.scala
@@ -121,51 +121,6 @@ class TestSuiteRunnerTest extends TestSuite with State[TestSuiteTestCase]:
               case Left(_) => fail("Unexpected Left")
               case Right(result) => expect(result.ignored).toEqual(1)
 
-    "running the FocusedStatelessTestSuite" using (_.focusedStatelessTestSuite) to:
-      "report that 2 tests were run" in:
-        state =>
-          whenComplete(state.runAll()):
-            possible => possible match
-              case Left(_) => fail("Unexpected Left")
-              case Right(result) => expect(result.successful).toEqual(2)
-
-      "report that 1 test was ignored" in:
-        state =>
-          whenComplete(state.runAll()):
-            possible => possible match
-              case Left(_) => fail("Unexpected Left")
-              case Right(result) => expect(result.ignored).toEqual(1)
-
-    "running the FocusedStatefulTestSuite" using (_.focusedStatefulTestSuite) to:
-      "report that 2 tests were run" in:
-        state =>
-          whenComplete(state.runAll()):
-            possible => possible match
-              case Left(_) => fail("Unexpected Left")
-              case Right(result) => expect(result.successful).toEqual(2)
-
-      "report that 1 test was ignored" in:
-        state =>
-          whenComplete(state.runAll()):
-            possible => possible match
-              case Left(_) => fail("Unexpected Left")
-              case Right(result) => expect(result.ignored).toEqual(1)
-
-    "running the FocusedAsyncStatefulTestSuite" using (_.focusedAsyncTestSuite) to:
-      "report that 2 tests were run" in:
-        state =>
-          whenComplete(state.runAll()):
-            possible => possible match
-              case Left(_) => fail("Unexpected Left")
-              case Right(result) => expect(result.successful).toEqual(2)
-
-      "report that 1 test was ignored" in:
-        state =>
-          whenComplete(state.runAll()):
-            possible => possible match
-              case Left(_) => fail("Unexpected Left")
-              case Right(result) => expect(result.ignored).toEqual(1)
-
     "when test suite cannot be instantiated" using (_.invalidTestSuiteClass) to :
       "a TestSuiteError should be received" in:
         state =>
@@ -183,21 +138,6 @@ class TestSuiteRunnerTest extends TestSuite with State[TestSuiteTestCase]:
       "should not be focused" in:
         state =>
           expect(state.evaluate().isFocused).toEqual(false)
-
-    "evaluting the FocusedStatelessTestSuite" using (_.focusedStatelessTestSuite) to :
-      "should be focused" in:
-        state =>
-          expect(state.evaluate().isFocused).toEqual(true)
-
-    "evaluting the FocusedStatefulTestSuite" using (_.focusedStatefulTestSuite) to :
-      "should be focused" in:
-        state =>
-          expect(state.evaluate().isFocused).toEqual(true)
-
-    "evaluting the FocusedStatefulTestSuite" using (_.focusedAsyncTestSuite) to :
-      "should be focused" in:
-        state =>
-          expect(state.evaluate().isFocused).toEqual(true)
 
   def expectErrorMatching(re: scala.util.matching.Regex): TestSuiteTestCase => Expectation =
     state =>
@@ -222,9 +162,6 @@ case class TestSuiteTestCase(suiteClassName: String = null) given (ec: Execution
   def setupFailureAsyncTestSuite = TestSuiteTestCase("intent.runner.StatefulFailingAsyncTestSuite")
   def noContextTestSuite = TestSuiteTestCase("intent.runner.StatefulNoContextTestSuite")
   def noContextAsyncTestSuite = TestSuiteTestCase("intent.runner.StatefulNoContextAsyncTestSuite")
-  def focusedStatelessTestSuite = TestSuiteTestCase("intent.runner.FocusedStatelessTestSuite")
-  def focusedStatefulTestSuite = TestSuiteTestCase("intent.runner.FocusedStatefulTestSuite")
-  def focusedAsyncTestSuite = TestSuiteTestCase("intent.runner.FocusedAsyncStatefulTestSuite")
 
 class OneOfEachResultTestSuite extends Stateless :
   "successful" in success()
@@ -272,26 +209,3 @@ class StatefulNoContextTestSuite extends State[StatefulFailingTestState]:
 class StatefulNoContextAsyncTestSuite extends AsyncState[StatefulFailingTestState]:
   "won't get here" in :
     _ => expect(1).toEqual(2)
-
-class FocusedStatelessTestSuite extends Stateless:
-  "should not be run" in fail("Test is not expected to run!")
-  "should be run" focus success()
-  "should also be run" focus success()
-
-class FocusedStatefulTestSuite extends State[Unit]:
-  "with state" using (()) to:
-    "should not be run" in:
-      _ => fail("Test is not expected to run!")
-    "should be run" focus:
-      _ => success()
-    "should also be run" focus:
-      _ => success()
-
-class FocusedAsyncStatefulTestSuite extends AsyncState[Unit]:
-  "with state" usingAsync (Future.successful(())) to:
-    "should not be run" in:
-      _ => fail("Test is not expected to run!")
-    "should be run" focus:
-      _ => success()
-    "should also be run" focus:
-      _ => success()


### PR DESCRIPTION
This PR adds two new keywords `focused` and `ignored` that can be used on context level to either focus or ignore an entire branch of tests.

* Ignore always have priority over focus.
* Can be combined with `ignore` and `focus`

Will try to extract some common behaviour regarding which context to use which now is repeated in multiple suites.

I am slightly reluctant to add new keywords, but using `focus` for stateless tests will be ambiguous between context and test case.

Implements #32