### PR TITLE
Upgrade to Dotty 0.19.0-RC1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ testFrameworks += new TestFramework("intent.sbt.Framework")
 
 Intent is an early adopter of Dotty features, which means:
 
-* You need a recent Dotty (>= `0.18.1-RC1`) since Intent use the new Scala 3 syntax
+* You need a recent Dotty (>= `0.19.0-RC1`) since Intent use the new Scala 3 syntax
  and significant whitespace.
 
 * Visual Studio Code seems to be the best supported editor (although not perfect)

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val dottyVersion = "0.18.1-RC1"
+val dottyVersion = "0.19.0-RC1"
 
 ThisBuild / name := "intent"
 ThisBuild / version := "0.1.0"
@@ -18,6 +18,8 @@ lazy val root = project
     organization := "com.factor10",
     libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0",
     testFrameworks += new TestFramework("intent.sbt.Framework"),
+
+    scalacOptions += "-Yindent-colons",
 
     // include the macro classes and resources in the main jar
     mappings in (Compile, packageBin) ++= mappings.in(macros, Compile, packageBin).value,

--- a/consume/build.sbt
+++ b/consume/build.sbt
@@ -1,4 +1,4 @@
-val dottyVersion = "0.18.1-RC1"
+val dottyVersion = "0.19.0-RC1"
 
 ThisBuild / name := "consume"
 ThisBuild / version := "0.0.1"

--- a/src/main/scala/intent/core/descriptiveness.scala
+++ b/src/main/scala/intent/core/descriptiveness.scala
@@ -2,6 +2,6 @@ package intent.core
 
 import intent.macros.Position
 
-object PositionDescription :
+object PositionDescription
   def (position: Position) contextualize (desc: String) =
     s"${desc} (${position.filePath}:${position.lineNumber0 + 1}:${position.columnNumber0 + 1})"

--- a/src/main/scala/intent/core/expect.scala
+++ b/src/main/scala/intent/core/expect.scala
@@ -22,7 +22,7 @@ import intent.core.expectations._
   */
 case class ListCutoff(maxItems: Int = 1000, printItems: Int = 5)
 
-class CompoundExpectation(inner: Seq[Expectation]) given (ec: ExecutionContext) extends Expectation:
+class CompoundExpectation(inner: Seq[Expectation])(given ec: ExecutionContext) extends Expectation
   def evaluate(): Future[ExpectationResult] =
     val innerFutures = inner.map(_.evaluate())
     Future.sequence(innerFutures).map { results =>
@@ -30,7 +30,7 @@ class CompoundExpectation(inner: Seq[Expectation]) given (ec: ExecutionContext) 
       ???
     }
 
-class Expect[T](blk: => T, position: Position, negated: Boolean = false):
+class Expect[T](blk: => T, position: Position, negated: Boolean = false)
   import PositionDescription._
 
   def evaluate(): T = blk
@@ -42,22 +42,22 @@ class Expect[T](blk: => T, position: Position, negated: Boolean = false):
 
 trait ExpectGivens {
 
-  given defaultListCutoff as ListCutoff = ListCutoff()
+  given defaultListCutoff: ListCutoff = ListCutoff()
 
   def (expect: Expect[T]) not[T]: Expect[T] = expect.negate()
 
-  def (expect: Expect[T]) toEqual[T] (expected: T) given (eqq: Eq[T], fmt: Formatter[T]): Expectation =
+  def (expect: Expect[T]) toEqual[T] (expected: T)(given eqq: Eq[T], fmt: Formatter[T]): Expectation =
     new EqualExpectation(expect, expected)
 
   // toMatch is partial
-  def (expect: Expect[String]) toMatch[T] (re: Regex) given (fmt: Formatter[String]): Expectation =
+  def (expect: Expect[String]) toMatch[T] (re: Regex)(given fmt: Formatter[String]): Expectation =
     new MatchExpectation(expect, re)
 
-  def (expect: Expect[Future[T]]) toCompleteWith[T] (expected: T) 
-      given (
-        eqq: Eq[T], 
-        fmt: Formatter[T], 
-        errFmt: Formatter[Throwable], 
+  def (expect: Expect[Future[T]]) toCompleteWith[T] (expected: T)
+     (given
+        eqq: Eq[T],
+        fmt: Formatter[T],
+        errFmt: Formatter[Throwable],
         ec: ExecutionContext,
         timeout: TestTimeout
       ): Expectation =
@@ -65,15 +65,15 @@ trait ExpectGivens {
 
   // We use ClassTag here to avoid "double definition error" wrt Expect[IterableOnce[T]]
   def (expect: Expect[Array[T]]) toContain[T : ClassTag] (expected: T)
-      given (
+     (given
         eqq: Eq[T],
         fmt: Formatter[T],
         cutoff: ListCutoff
       ): Expectation =
     new ArrayContainExpectation(expect, expected)
 
-  def (expect: Expect[IterableOnce[T]]) toContain[T] (expected: T) 
-      given (
+  def (expect: Expect[IterableOnce[T]]) toContain[T] (expected: T)
+     (given
         eqq: Eq[T],
         fmt: Formatter[T],
         cutoff: ListCutoff
@@ -81,25 +81,25 @@ trait ExpectGivens {
     new IterableContainExpectation(expect, expected)
 
   // Note: Not using IterableOnce here as it matches Option and we don't want that.
-  def (expect: Expect[Iterable[T]]) toEqual[T] (expected: Iterable[T]) 
-      given (
+  def (expect: Expect[Iterable[T]]) toEqual[T] (expected: Iterable[T])
+     (given
         eqq: Eq[T],
         fmt: Formatter[T]
       ): Expectation =
     new IterableEqualExpectation(expect, expected)
 
   // We use ClassTag here to avoid "double definition error" wrt Expect[Iterable[T]]
-  def (expect: Expect[Array[T]]) toEqual[T : ClassTag] (expected: Iterable[T]) 
-      given (
+  def (expect: Expect[Array[T]]) toEqual[T : ClassTag] (expected: Iterable[T])
+     (given
         eqq: Eq[T],
         fmt: Formatter[T]
       ): Expectation =
     new ArrayEqualExpectation(expect, expected)
-  
+
   /**
    * (1, 2, 3) toHaveLength 3
    */
-  def (expect: Expect[IterableOnce[T]]) toHaveLength[T] (expected: Int) given(ec: ExecutionContext): Expectation =
+  def (expect: Expect[IterableOnce[T]]) toHaveLength[T] (expected: Int)(given ec: ExecutionContext): Expectation =
     new LengthExpectation(expect, expected)
 
 

--- a/src/main/scala/intent/core/expect.scala
+++ b/src/main/scala/intent/core/expect.scala
@@ -40,7 +40,7 @@ class Expect[T](blk: => T, position: Position, negated: Boolean = false)
   def fail(desc: String): ExpectationResult = TestFailed(position.contextualize(desc), None)
   def pass: ExpectationResult               = TestPassed()
 
-trait ExpectGivens {
+trait ExpectGivens
 
   given defaultListCutoff: ListCutoff = ListCutoff()
 
@@ -113,4 +113,3 @@ trait ExpectGivens {
   //     - expect(myMap) toContain "foo" -> 42
   //     - expect(myMap) toContain(value(42))
   //     - expect(myMap).to.contain.key(42)
-}

--- a/src/main/scala/intent/core/expectations/contain.scala
+++ b/src/main/scala/intent/core/expectations/contain.scala
@@ -9,7 +9,7 @@ private def evalToContain[T](actual: IterableOnce[T],
                               expected: T,
                               expect: Expect[_],
                               listTypeName: String)
-    given (
+   (given
       eqq: Eq[T],
       fmt: Formatter[T],
       cutoff: ListCutoff
@@ -49,24 +49,24 @@ private def evalToContain[T](actual: IterableOnce[T],
     expect.fail(desc)
   else expect.pass
   Future.successful(r)
-  
-class IterableContainExpectation[T](expect: Expect[IterableOnce[T]], expected: T) 
-  given (
+
+class IterableContainExpectation[T](expect: Expect[IterableOnce[T]], expected: T)
+ (given
     eqq: Eq[T],
     fmt: Formatter[T],
     cutoff: ListCutoff
-  ) extends Expectation:
+  ) extends Expectation
 
   def evaluate(): Future[ExpectationResult] =
     val actual = expect.evaluate()
     evalToContain(actual, expected, expect, listTypeName(actual))
 
-class ArrayContainExpectation[T](expect: Expect[Array[T]], expected: T) 
-  given (
+class ArrayContainExpectation[T](expect: Expect[Array[T]], expected: T)
+ (given
     eqq: Eq[T],
     fmt: Formatter[T],
     cutoff: ListCutoff
-  ) extends Expectation:
+  ) extends Expectation
 
   def evaluate(): Future[ExpectationResult] =
     val actual = expect.evaluate()

--- a/src/main/scala/intent/core/expectations/equal.scala
+++ b/src/main/scala/intent/core/expectations/equal.scala
@@ -10,7 +10,7 @@ private def evalToEqual[T](actual: Iterable[T],
                             expect: Expect[_],
                             actualListTypeName: String,
                             expectedListTypeName: String)
-    given (
+   (given
       eqq: Eq[T],
       fmt: Formatter[T]
     ): Future[ExpectationResult] =
@@ -34,7 +34,7 @@ private def evalToEqual[T](actual: Iterable[T],
     expectedFormatted += fmt.format(expectedNext)
     if !eqq.areEqual(actualNext, expectedNext) then
       mismatch = true
-  
+
   val hasDiff = mismatch || actualIterator.hasNext || expectedIterator.hasNext
   val allGood = if expect.isNegated then hasDiff else !hasDiff
 
@@ -57,7 +57,7 @@ private def evalToEqual[T](actual: Iterable[T],
   Future.successful(r)
 
 class EqualExpectation[T](expect: Expect[T], expected: T)
-    given (eqq: Eq[T], fmt: Formatter[T]) extends Expectation:
+   (given eqq: Eq[T], fmt: Formatter[T]) extends Expectation
 
   def evaluate(): Future[ExpectationResult] =
     val actual = expect.evaluate()
@@ -78,10 +78,10 @@ class EqualExpectation[T](expect: Expect[T], expected: T)
     Future.successful(r)
 
 class IterableEqualExpectation[T](expect: Expect[Iterable[T]], expected: Iterable[T])
-  given (
+ (given
     eqq: Eq[T],
     fmt: Formatter[T]
-  ) extends Expectation:
+  ) extends Expectation
 
   def evaluate(): Future[ExpectationResult] =
     val actual = expect.evaluate()
@@ -89,10 +89,10 @@ class IterableEqualExpectation[T](expect: Expect[Iterable[T]], expected: Iterabl
 
 
 class ArrayEqualExpectation[T](expect: Expect[Array[T]], expected: Iterable[T])
-  given (
+ (given
     eqq: Eq[T],
     fmt: Formatter[T]
-  ) extends Expectation:
+  ) extends Expectation
 
   def evaluate(): Future[ExpectationResult] =
     val actual = expect.evaluate()

--- a/src/main/scala/intent/core/expectations/future.scala
+++ b/src/main/scala/intent/core/expectations/future.scala
@@ -7,13 +7,13 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Success, Failure}
 
 class ToCompleteWithExpectation[T](expect: Expect[Future[T]], expected: T)
-  given (
-    eqq: Eq[T], 
-    fmt: Formatter[T], 
-    errFmt: Formatter[Throwable], 
+ (given
+    eqq: Eq[T],
+    fmt: Formatter[T],
+    errFmt: Formatter[Throwable],
     ec: ExecutionContext,
     timeout: TestTimeout
-  ) extends Expectation:
+  ) extends Expectation
 
   def evaluate(): Future[ExpectationResult] =
     val timeoutFuture = DelayedFuture(timeout.timeout):

--- a/src/main/scala/intent/core/expectations/future.scala
+++ b/src/main/scala/intent/core/expectations/future.scala
@@ -22,17 +22,19 @@ class ToCompleteWithExpectation[T](expect: Expect[Future[T]], expected: T)
       case Success(actual) =>
         var comparisonResult = eqq.areEqual(actual, expected)
         if expect.isNegated then comparisonResult = !comparisonResult
+        val r =
+          if !comparisonResult then
+            val actualStr = fmt.format(actual)
+            val expectedStr = fmt.format(expected)
 
-        val r = if !comparisonResult then {
-          val actualStr = fmt.format(actual)
-          val expectedStr = fmt.format(expected)
-
-          val desc = if expect.isNegated then
-            s"Expected Future not to be completed with $expectedStr"
+            val desc = if expect.isNegated then
+              s"Expected Future not to be completed with $expectedStr"
+            else
+              s"Expected Future to be completed with $expectedStr but found $actualStr"
+            expect.fail(desc)
           else
-            s"Expected Future to be completed with $expectedStr but found $actualStr"
-          expect.fail(desc)
-        } else expect.pass
+            expect.pass
+
         Success(r)
       case Failure(t: TestTimeoutException) =>
         Success(expect.fail("Test timed out"))

--- a/src/main/scala/intent/core/expectations/match.scala
+++ b/src/main/scala/intent/core/expectations/match.scala
@@ -4,8 +4,8 @@ import intent.core._
 import scala.concurrent.Future
 import scala.util.matching.Regex
 
-class MatchExpectation[T](expect: Expect[String], re: Regex) 
-    given (fmt: Formatter[String]) extends Expectation:
+class MatchExpectation[T](expect: Expect[String], re: Regex)
+   (given fmt: Formatter[String]) extends Expectation
   def evaluate(): Future[ExpectationResult] =
     val actual = expect.evaluate()
 

--- a/src/main/scala/intent/core/expectations/size.scala
+++ b/src/main/scala/intent/core/expectations/size.scala
@@ -3,7 +3,7 @@ package intent.core.expectations
 import intent.core._
 import scala.concurrent.Future
 
-class LengthExpectation[T](expect: Expect[IterableOnce[T]], expected: Int) extends Expectation:
+class LengthExpectation[T](expect: Expect[IterableOnce[T]], expected: Int) extends Expectation
   def evaluate(): Future[ExpectationResult] =
     val actual = expect.evaluate()
     val actualLength = actual.iterator.size

--- a/src/main/scala/intent/core/formatters.scala
+++ b/src/main/scala/intent/core/formatters.scala
@@ -52,7 +52,5 @@ trait FormatterGivens
   given Formatter[Double] = DoubleFmt
   given Formatter[Float] = FloatFmt
 
-  given [TInner, T <: Option[TInner]](given Formatter[TInner]): Formatter[T] = OptionFmt[TInner, T]
-
-  // The use of ClassTag here prevents "double definition" error due to type erasure
-  given [TInner, T <: Try[TInner] : ClassTag](given Formatter[TInner]): Formatter[T] = TryFmt[TInner, T]
+  given optFmt[TInner, T <: Option[TInner]](given Formatter[TInner]): Formatter[T] = OptionFmt[TInner, T]
+  given tryFmt[TInner, T <: Try[TInner]](given Formatter[TInner]): Formatter[T] = TryFmt[TInner, T]

--- a/src/main/scala/intent/core/formatters.scala
+++ b/src/main/scala/intent/core/formatters.scala
@@ -3,56 +3,56 @@ package intent.core
 import scala.util.{Try, Success, Failure}
 import scala.reflect.ClassTag
 
-trait Formatter[T]:
+trait Formatter[T]
   def format(value: T): String
 
-object IntFmt extends Formatter[Int]:
+object IntFmt extends Formatter[Int]
   def format(i: Int): String = i.toString
 
-object LongFmt extends Formatter[Long]:
+object LongFmt extends Formatter[Long]
   def format(l: Long): String = l.toString
 
-object DoubleFmt extends Formatter[Double]:
+object DoubleFmt extends Formatter[Double]
   def format(d: Double): String = d.toString // TODO: Consider Locale here, maybe take as given??
 
-object FloatFmt extends Formatter[Float]:
+object FloatFmt extends Formatter[Float]
   def format(f: Float): String = f.toString // TODO: Consider Locale here, maybe take as given??
 
-object BooleanFmt extends Formatter[Boolean]:
+object BooleanFmt extends Formatter[Boolean]
   def format(b: Boolean): String = b.toString
 
-object StringFmt extends Formatter[String]:
+object StringFmt extends Formatter[String]
   def format(str: String): String = s""""$str""""
 
-object CharFmt extends Formatter[Char]:
+object CharFmt extends Formatter[Char]
   def format(ch: Char): String = s"'$ch'"
 
-class ThrowableFmt[T <: Throwable] extends Formatter[T]:
+class ThrowableFmt[T <: Throwable] extends Formatter[T]
   def format(t: T): String =
     // TODO: stack trace??
     s"${t.getClass.getName}: ${t.getMessage}"
 
-class OptionFmt[TInner, T <: Option[TInner]] given (innerFmt: Formatter[TInner]) extends Formatter[T]:
+class OptionFmt[TInner, T <: Option[TInner]](given innerFmt: Formatter[TInner]) extends Formatter[T]
   def format(value: T): String = value match
     case Some(x) => s"Some(${innerFmt.format(x)})"
     case None => "None"
 
-class TryFmt[TInner, T <: Try[TInner]] given (innerFmt: Formatter[TInner], throwableFmt: Formatter[Throwable]) extends Formatter[T]:
+class TryFmt[TInner, T <: Try[TInner]](given innerFmt: Formatter[TInner], throwableFmt: Formatter[Throwable]) extends Formatter[T]
   def format(value: T): String = value match
     case Success(x) => s"Success(${innerFmt.format(x)})"
     case Failure(t) => s"Failure(${throwableFmt.format(t)})"
 
-trait FormatterGivens:
-  given as Formatter[Int] = IntFmt
-  given as Formatter[Long] = LongFmt
-  given [T <: Throwable] as Formatter[T] = ThrowableFmt[T]
-  given as Formatter[Boolean] = BooleanFmt
-  given as Formatter[String] = StringFmt
-  given as Formatter[Char] = CharFmt
-  given as Formatter[Double] = DoubleFmt
-  given as Formatter[Float] = FloatFmt
+trait FormatterGivens
+  given Formatter[Int] = IntFmt
+  given Formatter[Long] = LongFmt
+  given [T <: Throwable]: Formatter[T] = ThrowableFmt[T]
+  given Formatter[Boolean] = BooleanFmt
+  given Formatter[String] = StringFmt
+  given Formatter[Char] = CharFmt
+  given Formatter[Double] = DoubleFmt
+  given Formatter[Float] = FloatFmt
 
-  given [TInner, T <: Option[TInner]] as Formatter[T] given Formatter[TInner] = OptionFmt[TInner, T]
+  given [TInner, T <: Option[TInner]](given Formatter[TInner]): Formatter[T] = OptionFmt[TInner, T]
 
   // The use of ClassTag here prevents "double definition" error due to type erasure
-  given [TInner, T <: Try[TInner] : ClassTag] as Formatter[T] given Formatter[TInner] = TryFmt[TInner, T]
+  given [TInner, T <: Try[TInner] : ClassTag](given Formatter[TInner]): Formatter[T] = TryFmt[TInner, T]

--- a/src/main/scala/intent/core/internal.scala
+++ b/src/main/scala/intent/core/internal.scala
@@ -19,7 +19,7 @@ private class ShouldNotHappenException(msg: String) extends RuntimeException(msg
 
 trait TestSupport extends FormatterGivens with EqGivens with ExpectGivens
 
-trait IntentStructure:
+trait IntentStructure
   private[intent] def allTestCases: Seq[ITestCase]
 
   /**
@@ -27,7 +27,7 @@ trait IntentStructure:
    */
   private[intent] def isFocused: Boolean
 
-case class IgnoredTestCase(nameParts: Seq[String]) extends ITestCase:
+case class IgnoredTestCase(nameParts: Seq[String]) extends ITestCase
   def run(): Future[TestCaseResult] =
     Future.successful(TestCaseResult(Duration.Zero, nameParts, TestIgnored()))
 
@@ -35,10 +35,10 @@ case class IgnoredTestCase(nameParts: Seq[String]) extends ITestCase:
 // TODO: to Eq/Formatting as well... we need a good strategy here!
 case class TestTimeout(timeout: FiniteDuration)
 
-trait TestLanguage:
-  def expect[T](expr: => T) given (pos: Position): Expect[T] = new Expect[T](expr, pos)
+trait TestLanguage
+  def expect[T](expr: => T)(given pos: Position): Expect[T] = new Expect[T](expr, pos)
 
-  def whenComplete[T](expr: => Future[T])(impl: T => Expectation) given (pos: Position, timeout: TestTimeout): Expectation =
+  def whenComplete[T](expr: => Future[T])(impl: T => Expectation)(given pos: Position, timeout: TestTimeout): Expectation =
     import PositionDescription._
     new Expectation:
       def evaluate(): Future[ExpectationResult] =
@@ -51,48 +51,46 @@ trait TestLanguage:
           case Failure(t) => Future.successful(
             TestFailed(pos.contextualize("The Future passed to 'whenComplete' failed"), Some(t)))
 
-  def fail(reason: String) given (pos: Position) =
+  def fail(reason: String)(given pos: Position): Expectation =
     import PositionDescription._
-    new Expectation:
-      def evaluate() = Future.successful(TestFailed(pos.contextualize(reason), None))
+    new { def evaluate() = Future.successful(TestFailed(pos.contextualize(reason), None)) }
 
-  def success() given (pos: Position) =
+  def success()(given pos: Position): Expectation =
     import PositionDescription._
-    new Expectation:
-      def evaluate() = Future.successful(TestPassed())
+    new { def evaluate() = Future.successful(TestPassed()) }
 
   // TODO: Can this be overridden? Or do we need a protected def
-  given executionContext as ExecutionContext = ExecutionContext.global
+  given executionContext: ExecutionContext = ExecutionContext.global
 
-  given defaultTestTimeout as TestTimeout = TestTimeout(5.seconds)
+  given defaultTestTimeout: TestTimeout = TestTimeout(5.seconds)
 
 /**
   * Base structure for Intent test cases, whether they are async, sync, stateful or stateless.
   * The structure is based on asynchronous execution, since it's possible to fit sync in async,
   * but not vice versa.
   */
-trait IntentStateBase[TState] extends IntentStructure with TestLanguage:
+trait IntentStateBase[TState] extends IntentStructure with TestLanguage
   type Map = TState => TState
   type FlatMap = TState => Future[TState]
 
   private[intent] def isStateful: Boolean
 
-  private[intent] sealed trait Context:
+  private[intent] sealed trait Context
     def name: String
     def transform(f: Future[Option[TState]]): Future[Option[TState]]
     def position: Position
     def expand(): Iterable[Context] = Seq(this)
-  private[intent] sealed case class ContextInit(name: String, init: () => Future[TState], position: Position) extends Context:
+  private[intent] sealed case class ContextInit(name: String, init: () => Future[TState], position: Position) extends Context
     def transform(f: Future[Option[TState]]) = init().map(Some.apply)
-  private[intent] sealed case class ContextMap(name: String, tx: Map, position: Position) extends Context:
+  private[intent] sealed case class ContextMap(name: String, tx: Map, position: Position) extends Context
     def transform(f: Future[Option[TState]]) = f.map(_.map(tx))
-  private[intent] sealed case class ContextFlatMap(name: String, tx: FlatMap, position: Position) extends Context:
+  private[intent] sealed case class ContextFlatMap(name: String, tx: FlatMap, position: Position) extends Context
     def transform(f: Future[Option[TState]]) =
       f.flatMap:
         case Some(state) => tx(state).map(Some.apply)
         case None        => throw ShouldNotHappenException("Unexpected state None after Future transform")
 
-  case class TestCase(contexts: Seq[Context], name: String, impl: TState => Expectation, tcPosition: Position) extends ITestCase:
+  case class TestCase(contexts: Seq[Context], name: String, impl: TState => Expectation, tcPosition: Position) extends ITestCase
     def nameParts: Seq[String] = contexts.map(_.name) :+ name
     def run(): Future[TestCaseResult] =
       import PositionDescription._
@@ -170,19 +168,19 @@ trait IntentStateBase[TState] extends IntentStructure with TestLanguage:
 
 /**
   * Provides the Intent stateful test syntax, i.e. where contexts arrange state and
-  * test cases act and assert on the state. 
+  * test cases act and assert on the state.
   */
-trait IntentStateSyntax[TState] extends IntentStateBase[TState]:
+trait IntentStateSyntax[TState] extends IntentStateBase[TState]
   private[intent] override def isStateful = true
 
-  def (context: String) using (init: => TState) given (pos: Position) : Context =
+  def (context: String) using (init: => TState)(given pos: Position) : Context =
     ContextInit(context, () => Future.successful(init), pos)
-  def (context: String) using (tx: Map) given (pos: Position) : Context =
+  def (context: String) using (tx: Map)(given pos: Position) : Context =
     ContextMap(context, tx, pos)
 
   def (ctx: Context) to (block: => Unit): Unit = withContext(ctx)(block)
 
-  def (testName: String) in (testImpl: TState => Expectation) given (pos: Position): Unit =
+  def (testName: String) in (testImpl: TState => Expectation)(given pos: Position): Unit =
     if inFocusedMode then
       testName ignore testImpl
     else
@@ -191,11 +189,11 @@ trait IntentStateSyntax[TState] extends IntentStateBase[TState]:
   def (testName: String) ignore (testImpl: TState => Expectation): Unit =
     addTestCase(IgnoredTestCase(contextsInOrder.map(_.name) :+ testName))
 
-  def (testName: String) focus (testImpl: TState => Expectation) given (pos: Position): Unit =
+  def (testName: String) focus (testImpl: TState => Expectation)(given pos: Position): Unit =
     enableFocusedMode()
     addTestCase(TestCase(contextsInOrder, testName, testImpl, pos))
 
-  private case class TableDriveContext(name: String, generator: () => Iterable[TState], position: Position) extends Context:
+  private case class TableDriveContext(name: String, generator: () => Iterable[TState], position: Position) extends Context
     def transform(f: Future[Option[TState]]): Future[Option[TState]] =
       Future.failed(new ShouldNotHappenException("TableDriveContext should not be used directly"))
     override def expand(): Iterable[Context] =
@@ -204,48 +202,48 @@ trait IntentStateSyntax[TState] extends IntentStateBase[TState]:
 
   // TODO: Move to separate trait?
   // TODO: Only works on root level currently...
-  def (context: String) usingTable (generator: => Iterable[TState]) given (pos: Position): Context =
+  def (context: String) usingTable (generator: => Iterable[TState])(given pos: Position): Context =
     TableDriveContext(context, () => generator, pos)
 
 /**
   * Provides the Intent stateless test syntax, i.e. where contexts are merely structural
   * and test cases are entirely responsible for arrange-act-assert.
   */
-trait IntentStatelessSyntax extends IntentStateBase[Unit]:
+trait IntentStatelessSyntax extends IntentStateBase[Unit]
 
   private[intent] override def isStateful = false
 
-  def (testName: String) in (testImpl: => Expectation) given (pos: Position): Unit =
+  def (testName: String) in (testImpl: => Expectation)(given pos: Position): Unit =
     // When in focused mode, all "ordinary" tests becomes ignored
     if inFocusedMode then
       testName ignore testImpl
     else
       addTestCase(TestCase(contextsInOrder, testName, _ => testImpl, pos))
 
-  def (blockName: String) apply (block: => Unit) given (pos: Position): Unit =
+  def (blockName: String) apply (block: => Unit)(given pos: Position): Unit =
     val ctx = ContextInit(blockName, () => Future.successful(()), pos)
     withContext(ctx)(block)
 
   def (testName: String) ignore (testImpl: => Expectation): Unit =
     addTestCase(IgnoredTestCase(contextsInOrder.map(_.name) :+ testName))
 
-  def (testName: String) focus (testImpl: => Expectation) given (pos: Position): Unit =
+  def (testName: String) focus (testImpl: => Expectation)(given pos: Position): Unit =
     enableFocusedMode()
     addTestCase(TestCase(contextsInOrder, testName, _ => testImpl, pos))
 
-trait IntentAsyncStateSyntax[TState] extends IntentStateBase[TState]:
+trait IntentAsyncStateSyntax[TState] extends IntentStateBase[TState]
 
   private[intent] override def isStateful = true
 
-  def (context: String) using (init: => TState) given (pos: Position): Context = ContextInit(context, () => Future.successful(init), pos)
-  def (context: String) usingAsync (init: => Future[TState]) given (pos: Position): Context = ContextInit(context, () => init, pos)
-  def (context: String) using (tx: Map) given (pos: Position): Context = ContextMap(context, tx, pos)
-  def (context: String) usingAsync (fmc: FlatMap) given (pos: Position): Context = ContextFlatMap(context, fmc, pos)
+  def (context: String) using (init: => TState)(given pos: Position): Context = ContextInit(context, () => Future.successful(init), pos)
+  def (context: String) usingAsync (init: => Future[TState])(given pos: Position): Context = ContextInit(context, () => init, pos)
+  def (context: String) using (tx: Map)(given pos: Position): Context = ContextMap(context, tx, pos)
+  def (context: String) usingAsync (fmc: FlatMap)(given pos: Position): Context = ContextFlatMap(context, fmc, pos)
 
   def (ctx: Context) to (block: => Unit): Unit =
     withContext(ctx)(block)
 
-  def (testName: String) in (testImpl: TState => Expectation) given (pos: Position): Unit =
+  def (testName: String) in (testImpl: TState => Expectation)(given pos: Position): Unit =
     if inFocusedMode then
       testName ignore testImpl
     else
@@ -254,6 +252,6 @@ trait IntentAsyncStateSyntax[TState] extends IntentStateBase[TState]:
   def (testName: String) ignore (testImpl: TState => Expectation): Unit =
       addTestCase(IgnoredTestCase(contextsInOrder.map(_.name) :+ testName))
 
-  def (testName: String) focus (testImpl: TState => Expectation) given (pos: Position): Unit =
+  def (testName: String) focus (testImpl: TState => Expectation)(given pos: Position): Unit =
     enableFocusedMode()
     addTestCase(TestCase(contextsInOrder, testName, testImpl, pos))

--- a/src/main/scala/intent/core/internal.scala
+++ b/src/main/scala/intent/core/internal.scala
@@ -114,7 +114,7 @@ trait IntentStateBase[TState] extends IntentStructure with TestLanguage
         case l@Left(_) => Future.successful(l)
         case Right(stateOpt) =>
           try
-            ctx.transform(Future.successful(stateOpt)).transform :
+            ctx.transform(Future.successful(stateOpt)).transform:
               case Success(newStateOpt) => Success(Right(newStateOpt))
               case Failure(t: ShouldNotHappenException) =>
                 Success(Left(error(s"""${t.getMessage} for context \"${ctx.name}\"""", None, ctx.position)))
@@ -126,7 +126,7 @@ trait IntentStateBase[TState] extends IntentStructure with TestLanguage
               Future.successful(Left(error(s"""The transformation for context \"${ctx.name}\" failed""", Some(t), ctx.position)))
       })
 
-      postSetup.flatMap :
+      postSetup.flatMap:
         case Left(r) => Future.successful(r)
         case Right(opt) =>
           try

--- a/src/main/scala/intent/core/observable.scala
+++ b/src/main/scala/intent/core/observable.scala
@@ -5,5 +5,5 @@ package intent.core
   * Originally part of a simple Observable pattern implementation, but this
   * is all we need right now.
   */
-trait Subscriber[T]:
+trait Subscriber[T]
   def onNext(event: T): Unit

--- a/src/main/scala/intent/core/structure.scala
+++ b/src/main/scala/intent/core/structure.scala
@@ -5,7 +5,7 @@ import scala.concurrent.Future
 
 abstract class TestSuite {}
 
-trait Expectation:
+trait Expectation
   private[intent] def evaluate(): Future[ExpectationResult]
 
 sealed trait ExpectationResult
@@ -35,6 +35,6 @@ case class TestIgnored() extends ExpectationResult
 
 case class TestCaseResult(duration: FiniteDuration, qualifiedName: Seq[String], expectationResult: ExpectationResult)
 
-trait ITestCase:
+trait ITestCase
   def nameParts: Seq[String]
   def run(): Future[TestCaseResult]

--- a/src/main/scala/intent/runner/TestSuiteRunner.scala
+++ b/src/main/scala/intent/runner/TestSuiteRunner.scala
@@ -22,7 +22,7 @@ case class TestSuiteError(ex: Throwable) extends Throwable
  * @param errors The number of tests that caused error (exception, not failed assertion)
  * @param ignored The number of tests that are ignored (not run)
  */
-case class TestSuiteResult(total: Int = 0, successful: Int = 0, failed: Int = 0, errors: Int = 0, ignored: Int = 0):
+case class TestSuiteResult(total: Int = 0, successful: Int = 0, failed: Int = 0, errors: Int = 0, ignored: Int = 0)
   def incSuccess(): TestSuiteResult = this.copy(
       total = total + 1,
       successful = successful + 1)
@@ -47,7 +47,7 @@ case class TestSuiteResult(total: Int = 0, successful: Int = 0, failed: Int = 0,
  *
  * @param classLoader The class loader used to load and instantiate the test suite
  */
-class TestSuiteRunner(classLoader: ClassLoader):
+class TestSuiteRunner(classLoader: ClassLoader)
   /**
    * Instantiate and run the given test suite.
    *
@@ -57,7 +57,7 @@ class TestSuiteRunner(classLoader: ClassLoader):
    * Until the full suite is executed a subscriber can be given to receive events during the test-run. A custom
    * subscriber is also recommended if more details than the successful result is needed.
    */
-  def runSuite(className: String, eventSubscriber: Option[Subscriber[TestCaseResult]] = None) given(ec: ExecutionContext): Future[Either[TestSuiteError, TestSuiteResult]] =
+  def runSuite(className: String, eventSubscriber: Option[Subscriber[TestCaseResult]] = None)(given ec: ExecutionContext): Future[Either[TestSuiteError, TestSuiteResult]] =
     instantiateSuite(className) match
       case Success(instance) => runTestsForSuite(instance, eventSubscriber).map(res => Right(res))
       case Failure(ex: Throwable) => Future.successful(Left(TestSuiteError(ex)))
@@ -70,7 +70,7 @@ class TestSuiteRunner(classLoader: ClassLoader):
       case Success(instance) => Right(instance)
       case Failure(ex: Throwable) => Left(TestSuiteError(ex))
 
-  private def runTestsForSuite(suite: IntentStructure, eventSubscriber: Option[Subscriber[TestCaseResult]]) given(ec: ExecutionContext): Future[TestSuiteResult] =
+  private def runTestsForSuite(suite: IntentStructure, eventSubscriber: Option[Subscriber[TestCaseResult]])(given ec: ExecutionContext): Future[TestSuiteResult] =
     // TODO: We should measure Suite time as well. Might be good to find expensive setup or scheduling problems.
     val futureTestResults = suite.allTestCases.map(tc =>
       eventSubscriber match {

--- a/src/main/scala/intent/sbt/Runner.scala
+++ b/src/main/scala/intent/sbt/Runner.scala
@@ -132,7 +132,7 @@ case class FailedEvent(duration: Long, suiteName: String, testNames: Seq[String]
     loggers.foreach(_.info(color + s"[${prefix}] ${fullyQualifiedTestName} (${executionTime} ms) \n\t${color}${assertionMessage}${error}"))
 
 case class ErrorEvent(duration: Long, suiteName: String, testNames: Seq[String], fingerprint: Fingerprint, focusMode: Boolean, errContext: String, err: Option[Throwable]) extends Event
-  with LoggedEvent(Console.RED, "ERROR", suiteName, testNames) {
+  with LoggedEvent(Console.RED, "ERROR", suiteName, testNames)
   val color = Console.RED // Why are not these inherited form LoggedEvent?
   val prefix = "ERROR"
 
@@ -143,7 +143,6 @@ case class ErrorEvent(duration: Long, suiteName: String, testNames: Seq[String],
   override def log(loggers: Array[Logger], executionTime: Long): Unit =
     val error = err.map(e => "\n\n" + printErrorWithPrefix(e, s"\t${color}")).getOrElse("")
     loggers.foreach(_.info(color + s"[${prefix}] ${fullyQualifiedTestName} (${executionTime} ms) \n\t${color}${errContext}${error}"))
-}
 
 case class IgnoredEvent(suiteName: String, testNames: Seq[String], fingerprint: Fingerprint, focusMode: Boolean) extends Event
   with LoggedEvent(Console.YELLOW, "IGNORED", suiteName, testNames)

--- a/src/main/scala/intent/sbt/Runner.scala
+++ b/src/main/scala/intent/sbt/Runner.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration._
 import scala.language.implicitConversions
 import java.io.{PrintWriter, StringWriter}
 
-class Framework extends SFramework:
+class Framework extends SFramework
   def name(): String = "intent"
   def fingerprints(): Array[Fingerprint] = Array(IntentFingerprint)
   def runner(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader): Runner =
@@ -21,7 +21,7 @@ private def printErrorWithPrefix(t: Throwable, linePrefix: String): String =
 /**
  * Defines how to find the Intent's test classes
  */
-object IntentFingerprint extends SubclassFingerprint:
+object IntentFingerprint extends SubclassFingerprint
   // Disable the usage of modules (singleton objects) - this makes discovery faster
   val isModule = false
 
@@ -37,7 +37,7 @@ object IntentFingerprint extends SubclassFingerprint:
 class SbtRunner(
   val args: Array[String],
   val remoteArgs: Array[String],
-  classLoader: ClassLoader) extends Runner:
+  classLoader: ClassLoader) extends Runner
 
   def done(): String =
     // This is called when test is done, and after that the test task myst not be called
@@ -73,7 +73,7 @@ class SbtRunner(
     potentialSuites
       .map(s => SbtTask(s.td, s.structure, runner, focusMode))
 
-class SbtTask(td: TaskDef, suit: IntentStructure, runner: TestSuiteRunner, focusMode: Boolean) extends Task:
+class SbtTask(td: TaskDef, suit: IntentStructure, runner: TestSuiteRunner, focusMode: Boolean) extends Task
   import scala.concurrent.{Await, Future}
   import scala.concurrent.duration._
   import scala.concurrent.ExecutionContext
@@ -89,7 +89,7 @@ class SbtTask(td: TaskDef, suit: IntentStructure, runner: TestSuiteRunner, focus
     // Hmm, do we need really to block here? Does SBT come with something included to be async
     Await.result(executeSuite(handler, loggers), Duration.Inf)
 
-  private def executeSuite(handler: EventHandler, loggers: Array[Logger]) given (ec: ExecutionContext): Future[Array[Task]] =
+  private def executeSuite(handler: EventHandler, loggers: Array[Logger])(given ec: ExecutionContext): Future[Array[Task]] =
     object lock
     val eventSubscriber = new Subscriber[TestCaseResult]:
       override def onNext(event: TestCaseResult): Unit =
@@ -104,13 +104,13 @@ class SbtTask(td: TaskDef, suit: IntentStructure, runner: TestSuiteRunner, focus
 
     runner.runSuite(td.fullyQualifiedName, Some(eventSubscriber)).map(_ => Array.empty)
 
-trait LoggedEvent(color: String, prefix: String, suiteName: String, testNames: Seq[String]):
+trait LoggedEvent(color: String, prefix: String, suiteName: String, testNames: Seq[String])
   val fullyQualifiedTestName: String = suiteName + " >> " + testNames.mkString(" >> ")
 
   def log(loggers: Array[Logger], executionTime: Long): Unit = loggers.foreach(_.info(color + s"[${prefix}] ${fullyQualifiedTestName} (${executionTime} ms)"))
 
 case class SuccessfulEvent(duration: Long, suiteName: String, testNames: Seq[String], fingerprint: Fingerprint, focusMode: Boolean) extends Event
-  with LoggedEvent(Console.GREEN, "PASSED", suiteName, testNames):
+  with LoggedEvent(Console.GREEN, "PASSED", suiteName, testNames)
 
   override def fullyQualifiedName = suiteName
   override def status = sbt.testing.Status.Success
@@ -118,7 +118,7 @@ case class SuccessfulEvent(duration: Long, suiteName: String, testNames: Seq[Str
   override def throwable(): sbt.testing.OptionalThrowable = sbt.testing.OptionalThrowable()
 
 case class FailedEvent(duration: Long, suiteName: String, testNames: Seq[String], fingerprint: Fingerprint, focusMode: Boolean, assertionMessage: String, err: Option[Throwable]) extends Event
-  with LoggedEvent(Console.RED, "FAILED", suiteName, testNames):
+  with LoggedEvent(Console.RED, "FAILED", suiteName, testNames)
   val color = Console.RED // Why are not these inherited form LoggedEvent?
   val prefix = "FAILED"
 
@@ -146,7 +146,7 @@ case class ErrorEvent(duration: Long, suiteName: String, testNames: Seq[String],
 }
 
 case class IgnoredEvent(suiteName: String, testNames: Seq[String], fingerprint: Fingerprint, focusMode: Boolean) extends Event
-  with LoggedEvent(Console.YELLOW, "IGNORED", suiteName, testNames):
+  with LoggedEvent(Console.YELLOW, "IGNORED", suiteName, testNames)
 
   override def duration = 0L
   override def fullyQualifiedName = suiteName

--- a/src/main/scala/intent/util/futures.scala
+++ b/src/main/scala/intent/util/futures.scala
@@ -7,9 +7,8 @@ import scala.concurrent.duration.Duration
 import scala.concurrent._
 import scala.util.Try
 
-trait DelayedFuture[T] extends Future[T] {
+trait DelayedFuture[T] extends Future[T]
   def cancel(): Unit
-}
 
 // From: http://stackoverflow.com/questions/16359849/scala-scheduledfuture
 object DelayedFuture

--- a/src/test/scala/intent/formatters/FormatTest.scala
+++ b/src/test/scala/intent/formatters/FormatTest.scala
@@ -3,22 +3,22 @@ package intent.formatters
 import intent._
 import scala.util.{Success, Failure, Try}
 
-class FormatTest extends TestSuite with Stateless:
-  "Formatting" :
+class FormatTest extends TestSuite with Stateless
+  "Formatting":
     "supports Long" in expect(format(42L)).toEqual("42")
     "surrounds Char in single quotes" in expect(format('a')).toEqual("'a'")
     "surrounds String in double quotes" in expect(format("a")).toEqual("\"a\"")
     "supports Option-Some" in expect(format(Some(42))).toEqual("Some(42)")
     "supports Option-None" in expect(format[Option[String]](None)).toEqual("None")
     "supports Try-Success" in expect(format(Success(42))).toEqual("Success(42)")
-    "supports Try-Failure" in expect(format(Failure(RuntimeException("oops")))).toEqual("Failure(java.lang.RuntimeException: oops)")
-    "supports Try as Try" in :
+    "supports Try-Failure" in expect(format[Try[Int]](Failure(RuntimeException("oops")))).toEqual("Failure(java.lang.RuntimeException: oops)")
+    "supports Try as Try" in:
       val t: Try[Int] = Success(42)
       expect(format(t)).toEqual("Success(42)")
     "supports recursive Option" in expect(format(Some("test"))).toEqual("Some(\"test\")")
-    "supports Throwable" in :
+    "supports Throwable" in:
       val t = RuntimeException("oops")
       expect(format(t)).toEqual("java.lang.RuntimeException: oops")
 
-  def format[T](x: T) given (fmt: core.Formatter[T]): String =
+  def format[T](x: T)(given fmt: core.Formatter[T]): String =
     fmt.format(x)

--- a/src/test/scala/intent/helpers/Meta.scala
+++ b/src/test/scala/intent/helpers/Meta.scala
@@ -8,7 +8,7 @@ trait Meta
   self: TestLanguage with TestSupport =>
     def runExpectation(e: => Expectation, expected: String)(given ExecutionContext): Expectation =
       val expectedFileName = getClass.getSimpleName // Assume class X is in X.scala
-      new Expectation :
+      new Expectation:
         def evaluate(): Future[ExpectationResult] =
           e.evaluate().flatMap:
             case TestFailed(s, _) =>

--- a/src/test/scala/intent/helpers/Meta.scala
+++ b/src/test/scala/intent/helpers/Meta.scala
@@ -4,9 +4,9 @@ import intent.core._
 import scala.concurrent.{Future, ExecutionContext}
 import java.util.regex.Pattern
 
-trait Meta:
+trait Meta
   self: TestLanguage with TestSupport =>
-    def runExpectation(e: => Expectation, expected: String) given (ExecutionContext): Expectation =
+    def runExpectation(e: => Expectation, expected: String)(given ExecutionContext): Expectation =
       val expectedFileName = getClass.getSimpleName // Assume class X is in X.scala
       new Expectation :
         def evaluate(): Future[ExpectationResult] =

--- a/src/test/scala/intent/helpers/TestSuiteRunnerTester.scala
+++ b/src/test/scala/intent/helpers/TestSuiteRunnerTester.scala
@@ -7,7 +7,7 @@ import intent.runner.{TestSuiteRunner, TestSuiteError, TestSuiteResult}
 /**
 * Supports running a test suite and checking the result.
 */
-trait TestSuiteRunnerTester given (ec: ExecutionContext) extends Subscriber[TestCaseResult]:
+trait TestSuiteRunnerTester(given ec: ExecutionContext) extends Subscriber[TestCaseResult]
 
   def suiteClassName: String
 

--- a/src/test/scala/intent/matchers/ExpectTest.scala
+++ b/src/test/scala/intent/matchers/ExpectTest.scala
@@ -5,7 +5,7 @@ import intent._
 import scala.concurrent.Future
 
 class ExpectTest extends TestSuite with Stateless
-  "an expectation" :
+  "an expectation":
     "can be negated" in expect(1 + 2).not.toEqual(4)
 
     "can check a Future" in:

--- a/src/test/scala/intent/matchers/ExpectTest.scala
+++ b/src/test/scala/intent/matchers/ExpectTest.scala
@@ -4,7 +4,7 @@ import intent._
 
 import scala.concurrent.Future
 
-class ExpectTest extends TestSuite with Stateless:
+class ExpectTest extends TestSuite with Stateless
   "an expectation" :
     "can be negated" in expect(1 + 2).not.toEqual(4)
 

--- a/src/test/scala/intent/matchers/FailureTest.scala
+++ b/src/test/scala/intent/matchers/FailureTest.scala
@@ -8,76 +8,76 @@ import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration._
 
 class FailureTest extends TestSuite with Stateless with Meta
-  "a toEqual failure" :
-    "is described properly" in :
+  "a toEqual failure":
+    "is described properly" in:
       runExpectation(expect(1).toEqual(2), "Expected 2 but found 1")
 
-    "is described properly in the negative" in :
+    "is described properly in the negative" in:
       runExpectation(expect(1).not.toEqual(1), "Expected 1 not to equal 1")
 
-    "is described properly with Option" in :
+    "is described properly with Option" in:
       runExpectation(expect(Some(1)).toEqual(None), "Expected None but found Some(1)")
 
-    "is described properly for Iterables, when actual is longer" in :
+    "is described properly for Iterables, when actual is longer" in:
       runExpectation(expect(Seq(1, 2)).toEqual(Seq(1)),
         "Expected List(1, 2) to equal List(1)")
 
-    "is described properly for Iterables, when actual is shorter" in :
+    "is described properly for Iterables, when actual is shorter" in:
       runExpectation(expect(Seq(1, 2)).toEqual(Seq(1, 2, 3)),
         "Expected List(1, 2) to equal List(1, 2, 3)")
 
-    "is described properly for Arrays" in :
+    "is described properly for Arrays" in:
       runExpectation(expect(Array(1, 2)).toEqual(Array(1)),
         "Expected Array(1, 2) to equal Array(1)")
 
-    "is described properly for Array-Iterable" in :
+    "is described properly for Array-Iterable" in:
       runExpectation(expect(Array(1, 2)).toEqual(Seq(1)),
         "Expected Array(1, 2) to equal List(1)")
 
-    "with custom formatting" in :
+    "with custom formatting" in:
       given customIntFmt: core.Formatter[Int]
         def format(a: Int): String = a.toString.replace("4", "forty-")
       runExpectation(expect(42).toEqual(43),
         "Expected forty-3 but found forty-2")
 
-  "a toMatch failure" :
-    "is described properly" in :
+  "a toMatch failure":
+    "is described properly" in:
       runExpectation(expect("foobar").toMatch("^bar".r), "Expected \"foobar\" to match /^bar/")
 
-    "is described properly in the negative" in :
+    "is described properly in the negative" in:
       runExpectation(expect("foobar").not.toMatch("^foo".r), "Expected \"foobar\" not to match /^foo/")
 
-  "a toContain failure" :
-    "is described properly" in :
+  "a toContain failure":
+    "is described properly" in:
       runExpectation(expect(Seq(1, 2)).toContain(3), "Expected List(1, 2) to contain 3")
 
-    "is described properly in the negative" in :
+    "is described properly in the negative" in:
       runExpectation(expect(Seq(1, 2)).not.toContain(1), "Expected List(1, ...) not to contain 1")
 
-    "is described properly for Array" in :
+    "is described properly for Array" in:
       runExpectation(expect(Array(1, 2)).toContain(3), "Expected Array(1, 2) to contain 3")
 
-    "is described properly when item is found in infinite stream but it's not expected" in :
+    "is described properly when item is found in infinite stream but it's not expected" in:
       val s = LazyList.from(1)
       runExpectation(expect(s).not.toContain(4), "Expected LazyList(1, 2, 3, 4, ...) not to contain 4")
 
-    "is described properly when item is not found in infinite stream but it's expected" in :
+    "is described properly when item is not found in infinite stream but it's expected" in:
       val s = LazyList.from(1)
       runExpectation(expect(s).toContain(-1), "Expected LazyList(1, 2, 3, 4, 5, ...) to contain -1")
 
-  "using fail()" :
+  "using fail()":
     "should fail with the given description" in runExpectation(fail("Manually failed"), "Manually failed")
 
-  "Future timeout" :
-    "should abort a long-running test when whenComplete is used" in :
+  "Future timeout":
+    "should abort a long-running test when whenComplete is used" in:
       given customTimeout: TestTimeout = TestTimeout(50.millis)
       val p = Promise[Int]()
       runExpectation({
-        whenComplete(p.future) :
+        whenComplete(p.future):
           result => expect(result).toEqual(42)
       }, "Test timed out")
 
-    "should abort a long-running test when toCompleteWith is used" in :
+    "should abort a long-running test when toCompleteWith is used" in:
       given customTimeout: TestTimeout = TestTimeout(50.millis)
       val p = Promise[Int]()
       runExpectation({

--- a/src/test/scala/intent/matchers/FailureTest.scala
+++ b/src/test/scala/intent/matchers/FailureTest.scala
@@ -7,7 +7,7 @@ import intent.core.TestTimeout
 import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration._
 
-class FailureTest extends TestSuite with Stateless with Meta:
+class FailureTest extends TestSuite with Stateless with Meta
   "a toEqual failure" :
     "is described properly" in :
       runExpectation(expect(1).toEqual(2), "Expected 2 but found 1")
@@ -35,7 +35,7 @@ class FailureTest extends TestSuite with Stateless with Meta:
         "Expected Array(1, 2) to equal List(1)")
 
     "with custom formatting" in :
-      given customIntFmt as core.Formatter[Int] :
+      given customIntFmt: core.Formatter[Int]
         def format(a: Int): String = a.toString.replace("4", "forty-")
       runExpectation(expect(42).toEqual(43),
         "Expected forty-3 but found forty-2")
@@ -70,7 +70,7 @@ class FailureTest extends TestSuite with Stateless with Meta:
 
   "Future timeout" :
     "should abort a long-running test when whenComplete is used" in :
-      given customTimeout as TestTimeout = TestTimeout(50.millis)
+      given customTimeout: TestTimeout = TestTimeout(50.millis)
       val p = Promise[Int]()
       runExpectation({
         whenComplete(p.future) :
@@ -78,7 +78,7 @@ class FailureTest extends TestSuite with Stateless with Meta:
       }, "Test timed out")
 
     "should abort a long-running test when toCompleteWith is used" in :
-      given customTimeout as TestTimeout = TestTimeout(50.millis)
+      given customTimeout: TestTimeout = TestTimeout(50.millis)
       val p = Promise[Int]()
       runExpectation({
         expect(p.future).toCompleteWith(42)

--- a/src/test/scala/intent/matchers/ToCompleteWithTest.scala
+++ b/src/test/scala/intent/matchers/ToCompleteWithTest.scala
@@ -4,7 +4,7 @@ import intent.{Stateless, TestSuite}
 import scala.concurrent.Future
 
 class ToCompleteWithTest extends TestSuite with Stateless
-  "toCompleteWith" :
-    "for successful Future" :
+  "toCompleteWith":
+    "for successful Future":
         "should be completed" in expect(Future.successful("foo")).toCompleteWith("foo")
         "can be negated" in expect(Future.successful("foo")).not.toCompleteWith("bar")

--- a/src/test/scala/intent/matchers/ToCompleteWithTest.scala
+++ b/src/test/scala/intent/matchers/ToCompleteWithTest.scala
@@ -3,7 +3,7 @@ package intent.matchers
 import intent.{Stateless, TestSuite}
 import scala.concurrent.Future
 
-class ToCompleteWithTest extends TestSuite with Stateless:
+class ToCompleteWithTest extends TestSuite with Stateless
   "toCompleteWith" :
     "for successful Future" :
         "should be completed" in expect(Future.successful("foo")).toCompleteWith("foo")

--- a/src/test/scala/intent/matchers/ToContainTest.scala
+++ b/src/test/scala/intent/matchers/ToContainTest.scala
@@ -2,7 +2,7 @@ package intent.matchers
 
 import intent.{Stateless, TestSuite}
 
-class ToContainTest extends TestSuite with Stateless:
+class ToContainTest extends TestSuite with Stateless
   "toContain" :
     "a list of Int" :
       "should contain element" in expect(Seq(1, 2, 3)).toContain(2)
@@ -22,6 +22,6 @@ class ToContainTest extends TestSuite with Stateless:
         expect(list).not.toContain(-1)
 
       "can be contains-checked, but will not detect anything beyond the limit" in:
-        given cutoff as intent.core.ListCutoff = intent.core.ListCutoff(5)
+        given cutoff: intent.core.ListCutoff = intent.core.ListCutoff(5)
         val list = LazyList.from(1)
         expect(list).not.toContain(10)

--- a/src/test/scala/intent/matchers/ToContainTest.scala
+++ b/src/test/scala/intent/matchers/ToContainTest.scala
@@ -3,20 +3,20 @@ package intent.matchers
 import intent.{Stateless, TestSuite}
 
 class ToContainTest extends TestSuite with Stateless
-  "toContain" :
-    "a list of Int" :
+  "toContain":
+    "a list of Int":
       "should contain element" in expect(Seq(1, 2, 3)).toContain(2)
       "should **not** contain missing element" in expect(Seq(1, 2, 3)).not.toContain(4)
 
-    "a list of String" :
+    "a list of String":
       "should contain element" in expect(Seq("one", "two", "three")).toContain("two")
       "should **not** contain missing element" in expect(Seq("one", "two", "three")).not.toContain("four")
 
-    "a list of Boolean" :
+    "a list of Boolean":
       "should contain element" in expect(Seq(true, false)).toContain(false)
       "should **not** contain missing element" in expect(Seq(true)).not.toContain(false)
 
-    "an infinite list" :
+    "an infinite list":
       "can be contains-checked, but will abort" in:
         val list = LazyList.from(1)
         expect(list).not.toContain(-1)

--- a/src/test/scala/intent/matchers/ToEqualTest.scala
+++ b/src/test/scala/intent/matchers/ToEqualTest.scala
@@ -4,9 +4,9 @@ import intent.{Stateless, TestSuite}
 import scala.util.{Success, Failure, Try}
 
 class ToEqualTest extends TestSuite with Stateless
-  "toEqual" :
+  "toEqual":
 
-    "for Boolean" :
+    "for Boolean":
       "true should equal true" in expect(true).toEqual(true)
 
       "true should *not* equal false" in expect(true).not.toEqual(false)
@@ -15,7 +15,7 @@ class ToEqualTest extends TestSuite with Stateless
 
       "false should *note* equal true" in expect(false).not.toEqual(true)
 
-    "for String" :
+    "for String":
       "<empty> should equal <empty>" in expect("").toEqual("")
 
       "<foo> should equal <foo>" in expect("foo").toEqual("foo")
@@ -24,15 +24,15 @@ class ToEqualTest extends TestSuite with Stateless
 
       "<🤓> should equal <🤓>" in expect("🤓").toEqual("🤓")
 
-    "for Char" :
+    "for Char":
       "should support equality test" in expect('a').toEqual('a')
       "should support inequality test" in expect('a').not.toEqual('A')
 
-    "for Double" :
+    "for Double":
       "should support equality test" in expect(3.14d).toEqual(3.14d)
       "should support inequality test" in expect(3.14d).not.toEqual(2.72d)
 
-      "with precision" :
+      "with precision":
         "should test equal with 12 decimals" in expect(1.123456789123d).toEqual(1.123456789123d)
         "should allow diff in the 13th decimal" in expect(1.1234567891234d).toEqual(1.1234567891235d)
         "should allow customization of precision" in:
@@ -40,11 +40,11 @@ class ToEqualTest extends TestSuite with Stateless
             def numberOfDecimals: Int = 2
           expect(1.234d).toEqual(1.235d)
 
-    "for Float" :
+    "for Float":
       "should support equality test" in expect(3.14f).toEqual(3.14f)
       "should support inequality test" in expect(3.14f).not.toEqual(2.72f)
 
-      "with precision" :
+      "with precision":
         "should test equal with 6 decimals" in expect(1.123456f).toEqual(1.123456f)
         "should allow diff in the 7th decimal" in expect(1.1234567f).toEqual(1.1234568f)
         "should allow customization of precision" in:
@@ -52,33 +52,33 @@ class ToEqualTest extends TestSuite with Stateless
             def numberOfDecimals: Int = 2
           expect(1.234f).toEqual(1.235f)
 
-    "for Option" :
+    "for Option":
       "Some should equal Some" in expect(Some(42)).toEqual(Some(42))
       "Some should test inner equality" in expect(Some(42)).not.toEqual(Some(43))
       "Some should not equal None" in expect(Some(42)).not.toEqual(None)
       "None should equal None" in expect[Option[String]](None).toEqual(None)
-      "should consider custom equality" in :
+      "should consider custom equality" in:
         given customIntEq: intent.core.Eq[Int]
           def areEqual(a: Int, b: Int) = Math.abs(a - b) == 1
         expect(Some(42)).toEqual(Some(43))
 
-    "for Try" :
+    "for Try":
       "Success should equal Success" in expect[Try[Int]](Success(42)).toEqual(Success(42))
       "Success should test inner equality" in expect[Try[Int]](Success(42)).not.toEqual(Success(43))
       "Success should not equal Failure" in expect[Try[Int]](Success(42)).not.toEqual(Failure(new Exception("oops")))
-      "Failure should equal Failure" in :
+      "Failure should equal Failure" in:
         val ex = RuntimeException("oops")
         expect[Try[Int]](Failure(ex)).toEqual(Failure(ex))
-      "Failure should test inner equality" in :
+      "Failure should test inner equality" in:
         val ex1 = RuntimeException("oops1")
         val ex2 = RuntimeException("oops2")
         expect[Try[Int]](Failure(ex1)).not.toEqual(Failure(ex2))
 
-    "for Long" :
+    "for Long":
       "should support equality test" in expect(10L).toEqual(10L)
       "should support inequality test" in expect(10L).not.toEqual(11L)
 
-    "for collection" :
+    "for collection":
       "supports equality test" in expect(Seq(1, 2)).toEqual(Seq(1, 2))
       "detects inquality in shorter length" in expect(Seq(1, 2)).not.toEqual(Seq(1))
       "detects inquality in longer length" in expect(Seq(1, 2)).not.toEqual(Seq(1, 2, 3))
@@ -87,7 +87,7 @@ class ToEqualTest extends TestSuite with Stateless
         val list = LazyList.from(1)
         expect(list).toEqual(list)
 
-    "for array" :
+    "for array":
       "supports equality test" in expect(Array(1, 2)).toEqual(Array(1, 2))
       "detects inquality in item" in expect(Array(1, 2)).not.toEqual(Array(1, 3))
       "supports equality test with non-array" in expect(Array(1, 2)).toEqual(Seq(1, 2))

--- a/src/test/scala/intent/matchers/ToEqualTest.scala
+++ b/src/test/scala/intent/matchers/ToEqualTest.scala
@@ -3,7 +3,7 @@ package intent.matchers
 import intent.{Stateless, TestSuite}
 import scala.util.{Success, Failure, Try}
 
-class ToEqualTest extends TestSuite with Stateless:
+class ToEqualTest extends TestSuite with Stateless
   "toEqual" :
 
     "for Boolean" :
@@ -36,7 +36,7 @@ class ToEqualTest extends TestSuite with Stateless:
         "should test equal with 12 decimals" in expect(1.123456789123d).toEqual(1.123456789123d)
         "should allow diff in the 13th decimal" in expect(1.1234567891234d).toEqual(1.1234567891235d)
         "should allow customization of precision" in:
-          given customPrecision as intent.core.FloatingPointPrecision[Double] :
+          given customPrecision: intent.core.FloatingPointPrecision[Double]
             def numberOfDecimals: Int = 2
           expect(1.234d).toEqual(1.235d)
 
@@ -48,7 +48,7 @@ class ToEqualTest extends TestSuite with Stateless:
         "should test equal with 6 decimals" in expect(1.123456f).toEqual(1.123456f)
         "should allow diff in the 7th decimal" in expect(1.1234567f).toEqual(1.1234568f)
         "should allow customization of precision" in:
-          given customPrecision as intent.core.FloatingPointPrecision[Float] :
+          given customPrecision: intent.core.FloatingPointPrecision[Float]
             def numberOfDecimals: Int = 2
           expect(1.234f).toEqual(1.235f)
 
@@ -58,7 +58,7 @@ class ToEqualTest extends TestSuite with Stateless:
       "Some should not equal None" in expect(Some(42)).not.toEqual(None)
       "None should equal None" in expect[Option[String]](None).toEqual(None)
       "should consider custom equality" in :
-        given customIntEq as intent.core.Eq[Int] :
+        given customIntEq: intent.core.Eq[Int]
           def areEqual(a: Int, b: Int) = Math.abs(a - b) == 1
         expect(Some(42)).toEqual(Some(43))
 

--- a/src/test/scala/intent/matchers/ToHaveLengthTest.scala
+++ b/src/test/scala/intent/matchers/ToHaveLengthTest.scala
@@ -3,7 +3,7 @@ package intent.matchers
 import intent.{Stateless, TestSuite}
 
 class ToHaveLengthTest extends TestSuite with Stateless
-  "toHaveLength" :
+  "toHaveLength":
     "empty list should have length 0" in expect(Seq()).toHaveLength(0)
 
     "Seq(1) should have length 1" in expect(Seq(1)).toHaveLength(1)

--- a/src/test/scala/intent/matchers/ToHaveLengthTest.scala
+++ b/src/test/scala/intent/matchers/ToHaveLengthTest.scala
@@ -2,7 +2,7 @@ package intent.matchers
 
 import intent.{Stateless, TestSuite}
 
-class ToHaveLengthTest extends TestSuite with Stateless:
+class ToHaveLengthTest extends TestSuite with Stateless
   "toHaveLength" :
     "empty list should have length 0" in expect(Seq()).toHaveLength(0)
 

--- a/src/test/scala/intent/matchers/ToMatchTest.scala
+++ b/src/test/scala/intent/matchers/ToMatchTest.scala
@@ -3,8 +3,8 @@ package intent.matchers
 import intent.{Stateless, TestSuite}
 
 class ToMatchTest extends TestSuite with Stateless
-  "toMatch" :
-    "for String" :
+  "toMatch":
+    "for String":
       "should find match" in expect("foobar").toMatch("^foo".r)
 
       "should find non-match" in expect("foobar").not.toMatch("foo$".r)

--- a/src/test/scala/intent/matchers/ToMatchTest.scala
+++ b/src/test/scala/intent/matchers/ToMatchTest.scala
@@ -2,7 +2,7 @@ package intent.matchers
 
 import intent.{Stateless, TestSuite}
 
-class ToMatchTest extends TestSuite with Stateless:
+class ToMatchTest extends TestSuite with Stateless
   "toMatch" :
     "for String" :
       "should find match" in expect("foobar").toMatch("^foo".r)

--- a/src/test/scala/intent/runner/TestSuiteRunnerTest.scala
+++ b/src/test/scala/intent/runner/TestSuiteRunnerTest.scala
@@ -9,28 +9,28 @@ import intent.helpers.TestSuiteRunnerTester
 import scala.concurrent.{ExecutionContext, Future}
 
 class TestSuiteRunnerTest extends TestSuite with State[TestSuiteTestCase]
-  "TestSuiteRunner" using TestSuiteTestCase() to :
+  "TestSuiteRunner" using TestSuiteTestCase() to:
 
-    "running a stateful suite without context" using (_.noContextTestSuite) to :
+    "running a stateful suite without context" using (_.noContextTestSuite) to:
       "has an error event" in:
         expectErrorMatching("^Top-level test cases".r)
 
-    "running a suite that fails in setup" using (_.setupFailureTestSuite) to :
-      "reports that 1 test was run" in :
+    "running a suite that fails in setup" using (_.setupFailureTestSuite) to:
+      "reports that 1 test was run" in:
         state =>
-          whenComplete(state.runAll()) :
+          whenComplete(state.runAll()):
             case Left(_) => fail("unexpected Left")
             case Right(result) => expect(result.total).toEqual(1)
 
       "reports that 1 test failed" in:
         state =>
-          whenComplete(state.runAll()) :
+          whenComplete(state.runAll()):
             case Left(_) => fail("unexpected Left")
             case Right(result) => expect(result.failed).toEqual(1)
 
       "has a failure event with the exception" in:
         state =>
-          whenComplete(state.runWithEventSubscriber()) :
+          whenComplete(state.runWithEventSubscriber()):
             case Left(_) => fail("unexpected Left")
             case Right(_) =>
               val maybeEx = state.receivedEvents().collectFirst { case TestCaseResult(_, _, TestFailed(_, Some(ex))) => ex }
@@ -38,10 +38,10 @@ class TestSuiteRunnerTest extends TestSuite with State[TestSuiteTestCase]
                 case Some(ex) => expect(ex.getMessage).toEqual("intentional failure")
                 case None => fail("unexpected None")
 
-    "running an async stateful suite that fails in setup" using (_.setupFailureAsyncTestSuite) to :
+    "running an async stateful suite that fails in setup" using (_.setupFailureAsyncTestSuite) to:
       "collects exceptions for all the failure variants" in:
         state =>
-          whenComplete(state.runWithEventSubscriber()) :
+          whenComplete(state.runWithEventSubscriber()):
             case Left(_) => fail("unexpected Left")
             case Right(_) =>
               val exceptions = state.receivedEvents().collect { case TestCaseResult(_, _, TestFailed(_, Some(ex))) => ex }
@@ -51,7 +51,7 @@ class TestSuiteRunnerTest extends TestSuite with State[TestSuiteTestCase]
 
       "describes all the failure variants" in:
         state =>
-          whenComplete(state.runWithEventSubscriber()) :
+          whenComplete(state.runWithEventSubscriber()):
             case Left(_) => fail("unexpected Left")
             case Right(_) =>
               val messages = state.receivedEvents().collect { case TestCaseResult(_, _, TestFailed(msg, _)) => msg }
@@ -59,11 +59,11 @@ class TestSuiteRunnerTest extends TestSuite with State[TestSuiteTestCase]
               val combined = messages.mkString("|")
               expect(combined).toMatch("^The state setup".r) // TODO: this doesn't test all three
 
-    "running an async stateful suite without context" using (_.noContextAsyncTestSuite) to :
+    "running an async stateful suite without context" using (_.noContextAsyncTestSuite) to:
       "has an error event" in:
         expectErrorMatching("^Top-level test cases".r)
 
-    "running an empty suite" using (_.emptyTestSuite) to :
+    "running an empty suite" using (_.emptyTestSuite) to:
       "report that zero tests were run" in:
         state =>
           whenComplete(state.runAll()):
@@ -71,7 +71,7 @@ class TestSuiteRunnerTest extends TestSuite with State[TestSuiteTestCase]
               case Left(_) => fail("Unexpected Left")
               case Right(result) => expect(result.total).toEqual(0)  // TODO: Match on case class or individual fields?
 
-    "running the OneOfEachResultTestSuite (stateless)" using (_.oneOfEachResult) to :
+    "running the OneOfEachResultTestSuite (stateless)" using (_.oneOfEachResult) to:
       "report that totally 4 test was run" in:
         state =>
           whenComplete(state.runAll()):
@@ -166,7 +166,7 @@ class TestSuiteRunnerTest extends TestSuite with State[TestSuiteTestCase]
               case Left(_) => fail("Unexpected Left")
               case Right(result) => expect(result.ignored).toEqual(1)
 
-    "when test suite cannot be instantiated" using (_.invalidTestSuiteClass) to :
+    "when test suite cannot be instantiated" using (_.invalidTestSuiteClass) to:
       "a TestSuiteError should be received" in:
         state =>
           whenComplete(state.runAll()):
@@ -174,34 +174,34 @@ class TestSuiteRunnerTest extends TestSuite with State[TestSuiteTestCase]
               case Left(e) => expect(s"${e.ex.getClass}: ${e.ex.getMessage}").toEqual("class java.lang.ClassNotFoundException: foo.Bar")
               case Right(_) => expect(false).toEqual(true)
 
-    "evaluting an empty suite" using (_.emptyTestSuite) to :
+    "evaluting an empty suite" using (_.emptyTestSuite) to:
       "should not be focused" in:
         state =>
           expect(state.evaluate().isFocused).toEqual(false)
 
-    "evaluting the OneOfEachResultTestSuite" using (_.oneOfEachResult) to :
+    "evaluting the OneOfEachResultTestSuite" using (_.oneOfEachResult) to:
       "should not be focused" in:
         state =>
           expect(state.evaluate().isFocused).toEqual(false)
 
-    "evaluting the FocusedStatelessTestSuite" using (_.focusedStatelessTestSuite) to :
+    "evaluting the FocusedStatelessTestSuite" using (_.focusedStatelessTestSuite) to:
       "should be focused" in:
         state =>
           expect(state.evaluate().isFocused).toEqual(true)
 
-    "evaluting the FocusedStatefulTestSuite" using (_.focusedStatefulTestSuite) to :
+    "evaluting the FocusedStatefulTestSuite" using (_.focusedStatefulTestSuite) to:
       "should be focused" in:
         state =>
           expect(state.evaluate().isFocused).toEqual(true)
 
-    "evaluting the FocusedStatefulTestSuite" using (_.focusedAsyncTestSuite) to :
+    "evaluting the FocusedStatefulTestSuite" using (_.focusedAsyncTestSuite) to:
       "should be focused" in:
         state =>
           expect(state.evaluate().isFocused).toEqual(true)
 
   def expectErrorMatching(re: scala.util.matching.Regex): TestSuiteTestCase => Expectation =
     state =>
-      whenComplete(state.runWithEventSubscriber()) :
+      whenComplete(state.runWithEventSubscriber()):
         case Left(_) => fail("unexpected Left")
         case Right(_) =>
           val maybeMsg = state.receivedEvents().collectFirst { case TestCaseResult(_, _, TestError(msg, _)) => msg }
@@ -248,29 +248,29 @@ case class StatefulFailingTestState()
       throw new RuntimeException("intentional failure")
 
 class StatefulFailingTestSuite extends State[StatefulFailingTestState]
-  "root" using (StatefulFailingTestState()) to :
-    "uh oh" using (_.fail) to :
-      "won't get here" in :
+  "root" using (StatefulFailingTestState()) to:
+    "uh oh" using (_.fail) to:
+      "won't get here" in:
         _ => expect(1).toEqual(2)
 
 class StatefulFailingAsyncTestSuite extends AsyncState[StatefulFailingTestState]
-  "root" using (StatefulFailingTestState()) to :
-    "uh oh async" usingAsync (_.failAsync) to :
-      "won't get here" in :
+  "root" using (StatefulFailingTestState()) to:
+    "uh oh async" usingAsync (_.failAsync) to:
+      "won't get here" in:
         _ => expect(1).toEqual(2)
-    "uh oh sync" using (_.fail) to :
-      "won't get here" in :
+    "uh oh sync" using (_.fail) to:
+      "won't get here" in:
         _ => expect(1).toEqual(2)
-    "uh oh sync-fail-in-async" usingAsync (_.throwFail) to :
-      "won't get here" in :
+    "uh oh sync-fail-in-async" usingAsync (_.throwFail) to:
+      "won't get here" in:
         _ => expect(1).toEqual(2)
 
 class StatefulNoContextTestSuite extends State[StatefulFailingTestState]
-  "won't get here" in :
+  "won't get here" in:
     _ => expect(1).toEqual(2)
 
 class StatefulNoContextAsyncTestSuite extends AsyncState[StatefulFailingTestState]
-  "won't get here" in :
+  "won't get here" in:
     _ => expect(1).toEqual(2)
 
 class FocusedStatelessTestSuite extends Stateless

--- a/src/test/scala/intent/runner/TestSuiteRunnerTest.scala
+++ b/src/test/scala/intent/runner/TestSuiteRunnerTest.scala
@@ -8,7 +8,7 @@ import intent.helpers.TestSuiteRunnerTester
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class TestSuiteRunnerTest extends TestSuite with State[TestSuiteTestCase]:
+class TestSuiteRunnerTest extends TestSuite with State[TestSuiteTestCase]
   "TestSuiteRunner" using TestSuiteTestCase() to :
 
     "running a stateful suite without context" using (_.noContextTestSuite) to :
@@ -212,7 +212,7 @@ class TestSuiteRunnerTest extends TestSuite with State[TestSuiteTestCase]:
 /**
  * Wraps a runner for a specific test suite
  */
-case class TestSuiteTestCase(suiteClassName: String = null) given (ec: ExecutionContext) extends TestSuiteRunnerTester:
+case class TestSuiteTestCase(suiteClassName: String = null)(given ec: ExecutionContext) extends TestSuiteRunnerTester
 
   def emptyTestSuite = TestSuiteTestCase("intent.testdata.EmtpyTestSuite")
   def invalidTestSuiteClass = TestSuiteTestCase("foo.Bar")
@@ -226,7 +226,7 @@ case class TestSuiteTestCase(suiteClassName: String = null) given (ec: Execution
   def focusedStatefulTestSuite = TestSuiteTestCase("intent.runner.FocusedStatefulTestSuite")
   def focusedAsyncTestSuite = TestSuiteTestCase("intent.runner.FocusedAsyncStatefulTestSuite")
 
-class OneOfEachResultTestSuite extends Stateless :
+class OneOfEachResultTestSuite extends Stateless
   "successful" in success()
   "failed" in fail("test should fail")
   "ignored" ignore success()
@@ -234,12 +234,12 @@ class OneOfEachResultTestSuite extends Stateless :
   "error" in:
     throw new RuntimeException("test should fail")
 
-class OneOfEachResulStatefulTestSuite extends State[Unit] :
+class OneOfEachResulStatefulTestSuite extends State[Unit]
     "level" using (()) to:
       "ignored" ignore:
         _ => fail("Unexpected, test should be ignored")
 
-case class StatefulFailingTestState():
+case class StatefulFailingTestState()
     def fail: StatefulFailingTestState =
       throw new RuntimeException("intentional failure")
     def failAsync: Future[StatefulFailingTestState] =
@@ -247,13 +247,13 @@ case class StatefulFailingTestState():
     def throwFail: Future[StatefulFailingTestState] =
       throw new RuntimeException("intentional failure")
 
-class StatefulFailingTestSuite extends State[StatefulFailingTestState]:
+class StatefulFailingTestSuite extends State[StatefulFailingTestState]
   "root" using (StatefulFailingTestState()) to :
     "uh oh" using (_.fail) to :
       "won't get here" in :
         _ => expect(1).toEqual(2)
 
-class StatefulFailingAsyncTestSuite extends AsyncState[StatefulFailingTestState]:
+class StatefulFailingAsyncTestSuite extends AsyncState[StatefulFailingTestState]
   "root" using (StatefulFailingTestState()) to :
     "uh oh async" usingAsync (_.failAsync) to :
       "won't get here" in :
@@ -265,20 +265,20 @@ class StatefulFailingAsyncTestSuite extends AsyncState[StatefulFailingTestState]
       "won't get here" in :
         _ => expect(1).toEqual(2)
 
-class StatefulNoContextTestSuite extends State[StatefulFailingTestState]:
+class StatefulNoContextTestSuite extends State[StatefulFailingTestState]
   "won't get here" in :
     _ => expect(1).toEqual(2)
 
-class StatefulNoContextAsyncTestSuite extends AsyncState[StatefulFailingTestState]:
+class StatefulNoContextAsyncTestSuite extends AsyncState[StatefulFailingTestState]
   "won't get here" in :
     _ => expect(1).toEqual(2)
 
-class FocusedStatelessTestSuite extends Stateless:
+class FocusedStatelessTestSuite extends Stateless
   "should not be run" in fail("Test is not expected to run!")
   "should be run" focus success()
   "should also be run" focus success()
 
-class FocusedStatefulTestSuite extends State[Unit]:
+class FocusedStatefulTestSuite extends State[Unit]
   "with state" using (()) to:
     "should not be run" in:
       _ => fail("Test is not expected to run!")
@@ -287,7 +287,7 @@ class FocusedStatefulTestSuite extends State[Unit]:
     "should also be run" focus:
       _ => success()
 
-class FocusedAsyncStatefulTestSuite extends AsyncState[Unit]:
+class FocusedAsyncStatefulTestSuite extends AsyncState[Unit]
   "with state" usingAsync (Future.successful(())) to:
     "should not be run" in:
       _ => fail("Test is not expected to run!")

--- a/src/test/scala/intent/sbt/IgnoredTest.scala
+++ b/src/test/scala/intent/sbt/IgnoredTest.scala
@@ -5,6 +5,6 @@ import intent.{TestSuite, State, Stateless}
 // The ignored is used to manually verify that SBT reports ignored tests using correct
 // and summary. The actual runner and result are tested with other unit-tests.
 
-class IgnoredTest extends TestSuite with Stateless:
+class IgnoredTest extends TestSuite with Stateless
   "ignored test" ignore:
     fail("This should never fail, only be ignored!")

--- a/src/test/scala/intent/styles/AsyncTest.scala
+++ b/src/test/scala/intent/styles/AsyncTest.scala
@@ -6,13 +6,13 @@ import scala.concurrent.{Future, ExecutionContext}
 
 class AsyncTest extends TestSuite with Stateless with Meta
 
-  "an async test" :
-    "can use whenComplete" in :
+  "an async test":
+    "can use whenComplete" in:
       val f = Future { 21 * 2 }
       whenComplete(f):
         result => expect(result).toEqual(42)
 
-    "fails with failure in whenComplete" in :
+    "fails with failure in whenComplete" in:
       runExpectation({
         val f = Future[Int] { throw new RuntimeException("async failure") }
         whenComplete(f):
@@ -21,18 +21,18 @@ class AsyncTest extends TestSuite with Stateless with Meta
 
 class AsyncStateTest extends TestSuite with AsyncState[MyAsyncState] with Meta
 
-  "a test with async state" usingAsync Future{MyAsyncState("Hello")} to :
+  "a test with async state" usingAsync Future{MyAsyncState("Hello")} to:
     "can map on the state" using (_.map(" world")) to:
-      "and sees the appropriate state" in :
+      "and sees the appropriate state" in:
         state => expect(state.s).toEqual("Hello world")
 
-    "can async-map on the state" usingAsync (_.asyncMap(" async world")) to :
-      "sees the appropriate state" in :
+    "can async-map on the state" usingAsync (_.asyncMap(" async world")) to:
+      "sees the appropriate state" in:
         state => expect(state.s).toEqual("Hello async world")
 
-  "a test with initially sync state" using MyAsyncState("Hello") to :
-    "can async-map on the state" usingAsync (_.asyncMap(" async world")) to :
-      "sees the appropriate state" in :
+  "a test with initially sync state" using MyAsyncState("Hello") to:
+    "can async-map on the state" usingAsync (_.asyncMap(" async world")) to:
+      "sees the appropriate state" in:
         state => expect(state.s).toEqual("Hello async world")
 
 case class MyAsyncState(s: String)(given ExecutionContext)

--- a/src/test/scala/intent/styles/AsyncTest.scala
+++ b/src/test/scala/intent/styles/AsyncTest.scala
@@ -4,7 +4,7 @@ import intent._
 import helpers.Meta
 import scala.concurrent.{Future, ExecutionContext}
 
-class AsyncTest extends TestSuite with Stateless with Meta:
+class AsyncTest extends TestSuite with Stateless with Meta
 
   "an async test" :
     "can use whenComplete" in :
@@ -19,7 +19,7 @@ class AsyncTest extends TestSuite with Stateless with Meta:
           result => expect(result).toEqual(42)
       }, "The Future passed to 'whenComplete' failed")
 
-class AsyncStateTest extends TestSuite with AsyncState[MyAsyncState] with Meta:
+class AsyncStateTest extends TestSuite with AsyncState[MyAsyncState] with Meta
 
   "a test with async state" usingAsync Future{MyAsyncState("Hello")} to :
     "can map on the state" using (_.map(" world")) to:
@@ -35,6 +35,6 @@ class AsyncStateTest extends TestSuite with AsyncState[MyAsyncState] with Meta:
       "sees the appropriate state" in :
         state => expect(state.s).toEqual("Hello async world")
 
-case class MyAsyncState(s: String) given (ExecutionContext):
+case class MyAsyncState(s: String)(given ExecutionContext)
   def map(s2: String) = copy(s = s + s2)
   def asyncMap(s2: String) = Future { copy(s = s + s2) }

--- a/src/test/scala/intent/styles/StatefulTest.scala
+++ b/src/test/scala/intent/styles/StatefulTest.scala
@@ -3,10 +3,10 @@ package intent.styles
 import intent._
 
 class StatefulTest extends TestSuite with State[StatefulState]
-  "root context" using StatefulState() to :
-    "transforms a little" using (_.addOne()) to :
-      "to transform some more" using (_.addOne()) to :
-        "check the stuff" in :
+  "root context" using StatefulState() to:
+    "transforms a little" using (_.addOne()) to:
+      "to transform some more" using (_.addOne()) to:
+        "check the stuff" in:
           state => expect(state.stuff).toHaveLength(2)
 
 case class StatefulState(stuff: Seq[String] = Seq.empty)

--- a/src/test/scala/intent/styles/StatefulTest.scala
+++ b/src/test/scala/intent/styles/StatefulTest.scala
@@ -2,12 +2,12 @@ package intent.styles
 
 import intent._
 
-class StatefulTest extends TestSuite with State[StatefulState] :
+class StatefulTest extends TestSuite with State[StatefulState]
   "root context" using StatefulState() to :
     "transforms a little" using (_.addOne()) to :
       "to transform some more" using (_.addOne()) to :
         "check the stuff" in :
           state => expect(state.stuff).toHaveLength(2)
 
-case class StatefulState(stuff: Seq[String] = Seq.empty):
+case class StatefulState(stuff: Seq[String] = Seq.empty)
   def addOne(): StatefulState = copy(stuff = stuff :+ "one more")

--- a/src/test/scala/intent/styles/StatelessTest.scala
+++ b/src/test/scala/intent/styles/StatelessTest.scala
@@ -3,5 +3,5 @@ package intent.styles
 import intent._
 
 class StatelessTest extends TestSuite with Stateless
-  "a stateless test" :
+  "a stateless test":
     "works well" in (expect(1) toEqual 1)

--- a/src/test/scala/intent/styles/StatelessTest.scala
+++ b/src/test/scala/intent/styles/StatelessTest.scala
@@ -2,6 +2,6 @@ package intent.styles
 
 import intent._
 
-class StatelessTest extends TestSuite with Stateless:
+class StatelessTest extends TestSuite with Stateless
   "a stateless test" :
     "works well" in (expect(1) toEqual 1)

--- a/src/test/scala/intent/styles/TableDrivenTest.scala
+++ b/src/test/scala/intent/styles/TableDrivenTest.scala
@@ -2,7 +2,7 @@ package intent.styles
 
 import intent._
 
-class TableDrivenTest extends TestSuite with State[TableState]:
+class TableDrivenTest extends TestSuite with State[TableState]
   "Table-driven test" usingTable (myTable) to :
     "uses table data" in :
       s =>
@@ -14,5 +14,5 @@ class TableDrivenTest extends TestSuite with State[TableState]:
     TableState(-1, -2, -3)
   )
 
-case class TableState(a: Int, b: Int, sum: Int):
+case class TableState(a: Int, b: Int, sum: Int)
   override def toString = s"$a + $b should be $sum"

--- a/src/test/scala/intent/styles/TableDrivenTest.scala
+++ b/src/test/scala/intent/styles/TableDrivenTest.scala
@@ -3,8 +3,8 @@ package intent.styles
 import intent._
 
 class TableDrivenTest extends TestSuite with State[TableState]
-  "Table-driven test" usingTable (myTable) to :
-    "uses table data" in :
+  "Table-driven test" usingTable (myTable) to:
+    "uses table data" in:
       s =>
         expect(s.a + s.b).toEqual(s.sum)
 

--- a/src/test/scala/intent/suite/TestDiscoveryTest.scala
+++ b/src/test/scala/intent/suite/TestDiscoveryTest.scala
@@ -3,7 +3,7 @@ package intent.suite
 import intent.{TestSuite, State, Stateless}
 import intent.testdata._
 
-class TestDiscoveryTest extends TestSuite with State[TestDiscoveryTestState]:
+class TestDiscoveryTest extends TestSuite with State[TestDiscoveryTestState]
   "Test discovery" using TestDiscoveryTestState() to :
     "empty test suite" using (_.withSuite(EmtpyTestSuite())) to :
 
@@ -20,5 +20,5 @@ class TestDiscoveryTest extends TestSuite with State[TestDiscoveryTestState]:
       "should have 3 tests" in:
         st => expect(st.suite.allTestCases).toHaveLength(3)
 
-case class TestDiscoveryTestState(suite: Stateless = null):
+case class TestDiscoveryTestState(suite: Stateless = null)
   def withSuite(s: Stateless) = copy(suite = s)

--- a/src/test/scala/intent/suite/TestDiscoveryTest.scala
+++ b/src/test/scala/intent/suite/TestDiscoveryTest.scala
@@ -4,18 +4,18 @@ import intent.{TestSuite, State, Stateless}
 import intent.testdata._
 
 class TestDiscoveryTest extends TestSuite with State[TestDiscoveryTestState]
-  "Test discovery" using TestDiscoveryTestState() to :
-    "empty test suite" using (_.withSuite(EmtpyTestSuite())) to :
+  "Test discovery" using TestDiscoveryTestState() to:
+    "empty test suite" using (_.withSuite(EmtpyTestSuite())) to:
 
       "should have 0 tests" in:
         st => expect(st.suite.allTestCases).toHaveLength(0)
 
-    "single level test suite" using (_.withSuite(SingleLevelTestSuite())) to :
+    "single level test suite" using (_.withSuite(SingleLevelTestSuite())) to:
 
       "should have 1 tests" in:
         st => expect(st.suite.allTestCases).toHaveLength(1)
 
-    "nested test suite" using (_.withSuite(NestedTestsSuite())) to :
+    "nested test suite" using (_.withSuite(NestedTestsSuite())) to:
 
       "should have 3 tests" in:
         st => expect(st.suite.allTestCases).toHaveLength(3)

--- a/src/test/scala/intent/testdata/EmtpyTestSuite.scala
+++ b/src/test/scala/intent/testdata/EmtpyTestSuite.scala
@@ -2,4 +2,4 @@ package intent.testdata
 
 import intent.Stateless
 
-class EmtpyTestSuite extends Stateless:
+class EmtpyTestSuite extends Stateless

--- a/src/test/scala/intent/testdata/NestedTestsSuite.scala
+++ b/src/test/scala/intent/testdata/NestedTestsSuite.scala
@@ -2,7 +2,7 @@ package intent.testdata
 
 import intent.Stateless
 
-class NestedTestsSuite extends Stateless:
+class NestedTestsSuite extends Stateless
   "root suite" :
     "child suite" :
       "grand child suite" :

--- a/src/test/scala/intent/testdata/NestedTestsSuite.scala
+++ b/src/test/scala/intent/testdata/NestedTestsSuite.scala
@@ -3,9 +3,9 @@ package intent.testdata
 import intent.Stateless
 
 class NestedTestsSuite extends Stateless
-  "root suite" :
-    "child suite" :
-      "grand child suite" :
+  "root suite":
+    "child suite":
+      "grand child suite":
         "grand child test" in expect( 1 + 1 ).toEqual(2)
 
       "child test" in expect( 1 + 1 ).toEqual(2)

--- a/src/test/scala/intent/testdata/SingleLevelTestSuite.scala
+++ b/src/test/scala/intent/testdata/SingleLevelTestSuite.scala
@@ -2,6 +2,6 @@ package intent.testdata
 
 import intent.Stateless
 
-class SingleLevelTestSuite extends Stateless:
+class SingleLevelTestSuite extends Stateless
   "root suite" :
     "root test" in expect( 1 + 1 ).toEqual(2)

--- a/src/test/scala/intent/testdata/SingleLevelTestSuite.scala
+++ b/src/test/scala/intent/testdata/SingleLevelTestSuite.scala
@@ -3,5 +3,5 @@ package intent.testdata
 import intent.Stateless
 
 class SingleLevelTestSuite extends Stateless
-  "root suite" :
+  "root suite":
     "root test" in expect( 1 + 1 ).toEqual(2)

--- a/src/test/scala/intent/util/DelayedFutureTest.scala
+++ b/src/test/scala/intent/util/DelayedFutureTest.scala
@@ -10,9 +10,9 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.{Success, Try}
 
-class DelayedFutureTestState :
+class DelayedFutureTestState
   val executorService = Executors.newFixedThreadPool(1)
-  given executionContext as ExecutionContext = ExecutionContext.fromExecutorService(executorService)
+  given executionContext: ExecutionContext = ExecutionContext.fromExecutorService(executorService)
 
   val executorThreadId =
     // Determine the thread ID of the execution context, so we can compare with that in the tests.
@@ -20,12 +20,12 @@ class DelayedFutureTestState :
     executionContext.execute(() => p.success(Thread.currentThread().getId))
     Await.result(p.future, 2 seconds)
 
-  def run(f: given (ExecutionContext) => Expectation): Expectation = f
+  def run(f:(given ExecutionContext) => Expectation): Expectation = f
 
-object DelayedFutureTestState:
+object DelayedFutureTestState
   val instance = DelayedFutureTestState()
 
-class DelayedFutureTest extends TestSuite with State[DelayedFutureTestState] :
+class DelayedFutureTest extends TestSuite with State[DelayedFutureTestState]
 
   "A DelayedFuture" using (DelayedFutureTestState.instance) to :
 

--- a/src/test/scala/intent/util/DelayedFutureTest.scala
+++ b/src/test/scala/intent/util/DelayedFutureTest.scala
@@ -27,24 +27,23 @@ object DelayedFutureTestState
 
 class DelayedFutureTest extends TestSuite with State[DelayedFutureTestState]
 
-  "A DelayedFuture" using (DelayedFutureTestState.instance) to :
+  "A DelayedFuture" using (DelayedFutureTestState.instance) to:
 
-    "should run the callback in the supplied execution context" in :
+    "should run the callback in the supplied execution context" in:
       s =>
-        s.run :
+        s.run:
           val f = DelayedFuture(10 milliseconds)(Thread.currentThread().getId)
-          whenComplete(f) :
+          whenComplete(f):
             tid => expect(tid).toEqual(s.executorThreadId)
 
     "should be cancellable" in:
       s =>
         s.run:
           var hasRun = false
-          val f = DelayedFuture(100 milliseconds) {
+          val f = DelayedFuture(100 milliseconds):
             hasRun = true
-          }
           f.cancel()
-          whenComplete(f) :
+          whenComplete(f):
             _ => expect(hasRun).toEqual(false)
 
     "should have a default result after being cancelled" in:


### PR DESCRIPTION
fixes #30 

It compiles and passes the tests

Note: `intent.formatters.FormatTest::'supports Try-Failure'` failed to infer the implicit so I added an explicit type parameter of `Try[Int]`

Also I removed the ClassTag parameter from the given for `TryFmt[TInner, T]`, which I assume was added just to keep them as anonymous