### PR TITLE
toContain matcher for Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## PR
+
+* Add `.toContain` for `Map` objects
+  See [toContain](docs/matchers.md#.toContain)
+
 ## 0.3.0 (2019-11-03)
 
 * Upgrade to Dotty 0.20.0-RC1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Add `.toContain` for `Map` objects
   See [toContain](docs/matchers.md#.toContain)
 
+* Add `.toContainAllOf` for `Map` objects
+  See [toContain](docs/matchers.md#.toContainAllOf)
+
 ## 0.3.0 (2019-11-03)
 
 * Upgrade to Dotty 0.20.0-RC1

--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -72,10 +72,9 @@ Match a `Seq`/`List` (in fact, any `IterableOnce`) to have the expected length.
 
 ```scala
 expect(Seq("one")).toHaveLength(1)
-````
+```
 
 [Additional examples](https://github.com/factor10/intent/blob/master/src/test/scala/intent/matchers/ToHaveLengthTest.scala)
-
 
 ### .toContain
 

--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -84,14 +84,23 @@ Match if a given sequence (either `IterableOnce` or `Array`) contains the expect
 expect(Seq(1, 2, 3)).toContain(2)
 ```
 
-It can also be used with a `Map` to match if the given Map contains the expected key-value elements(s).
+It can also be used with a `Map` to match if the given Map contains the expected key-value pair.
 
 ```scala
 expect(Map("one" -> 1, "two" -> 2, "three" -> 3)).toContain("two" -> 2)
-expect(Map("one" -> 1, "two" -> 2, "three" -> 3)).toContainAllOf("two" -> 2, "one" -> 1)
 ```
 
 [Additional examples](https://github.com/factor10/intent/blob/master/src/test/scala/intent/matchers/ToContainTest.scala)
+
+### .toContainAllOf
+
+Match if a given `Map` contains *all* of the expected key-value pairs.
+
+```scala
+expect(Map("one" -> 1, "two" -> 2, "three" -> 3)).toContainAllOf("two" -> 2, "one" -> 1)
+```
+
+[Additional examples](https://github.com/factor10/intent/blob/master/src/test/scala/intent/matchers/ToContainAllOfTest.scala)
 
 ### .toCompleteWith
 

--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -85,6 +85,12 @@ Match if a given sequence (either `IterableOnce` or `Array`) contains the expect
 expect(Seq(1, 2, 3)).toContain(2)
 ```
 
+It can also be used with a `Map` to match if the given Map contains the expected key-value elements(s).
+
+```scala
+expect(Map("one" -> 1, "two" -> 2, "three" -> 3)).toContain("two" -> 2, "one" -> 1)
+```
+
 [Additional examples](https://github.com/factor10/intent/blob/master/src/test/scala/intent/matchers/ToContainTest.scala)
 
 ### .toCompleteWith

--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -87,7 +87,8 @@ expect(Seq(1, 2, 3)).toContain(2)
 It can also be used with a `Map` to match if the given Map contains the expected key-value elements(s).
 
 ```scala
-expect(Map("one" -> 1, "two" -> 2, "three" -> 3)).toContain("two" -> 2, "one" -> 1)
+expect(Map("one" -> 1, "two" -> 2, "three" -> 3)).toContain("two" -> 2)
+expect(Map("one" -> 1, "two" -> 2, "three" -> 3)).toContainAllOf("two" -> 2, "one" -> 1)
 ```
 
 [Additional examples](https://github.com/factor10/intent/blob/master/src/test/scala/intent/matchers/ToContainTest.scala)

--- a/src/main/scala/intent/core/core.scala
+++ b/src/main/scala/intent/core/core.scala
@@ -1,0 +1,7 @@
+package intent.core
+
+import scala.collection.mutable.{ Map => MMap }
+import scala.collection.immutable.{ Map => IMap }
+import scala.collection.Map
+
+type MapLike[K, V] = Map[K, V] | IMap[K, V] | MMap[K, V]

--- a/src/main/scala/intent/core/expect.scala
+++ b/src/main/scala/intent/core/expect.scala
@@ -81,6 +81,15 @@ trait ExpectGivens with
       ): Expectation =
     new IterableContainExpectation(expect, expected)
 
+  /**
+   * Expect that a key-value tuple exists in the given map
+   */
+  def [K, V](expect: Expect[Map[K, V]]) toContain (expected: (K, V))
+    (given
+       eqq: Eq[V],
+       fmt: Formatter[V]
+    ): Expectation = new MapContainExpectation(expect, expected)
+
   // Note: Not using IterableOnce here as it matches Option and we don't want that.
   def [T](expect: Expect[Iterable[T]]) toEqual (expected: Iterable[T])
      (given

--- a/src/main/scala/intent/core/expect.scala
+++ b/src/main/scala/intent/core/expect.scala
@@ -84,11 +84,20 @@ trait ExpectGivens with
   /**
    * Expect that a key-value tuple exists in the given map
    */
-  def [K, V](expect: Expect[Map[K, V]]) toContain (expected: (K, V)*)
+  def [K, V](expect: Expect[Map[K, V]]) toContain (expected: (K, V))
     (given
        eqq: Eq[V],
        fmt: Formatter[V]
-    ): Expectation = new MapContainExpectation(expect, expected)
+    ): Expectation = new MapContainExpectation(expect, Seq(expected))
+
+  /**
+   * Expect that multiple key-value tuple exists in the given map
+   */
+  def [K, V](expect: Expect[Map[K, V]]) toContainAllOf (expected: (K, V)*)
+  (given
+     eqq: Eq[V],
+     fmt: Formatter[V]
+  ): Expectation = new MapContainExpectation(expect, expected)
 
   // Note: Not using IterableOnce here as it matches Option and we don't want that.
   def [T](expect: Expect[Iterable[T]]) toEqual (expected: Iterable[T])

--- a/src/main/scala/intent/core/expect.scala
+++ b/src/main/scala/intent/core/expect.scala
@@ -4,12 +4,11 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Success, Failure}
 import scala.collection.IterableOnce
 import scala.collection.mutable.ListBuffer
-import scala.collection.mutable.{Map  => MMap}
 import scala.language.implicitConversions
 import scala.util.matching.Regex
 import scala.reflect.ClassTag
 
-import intent.core.{Expectation, ExpectationResult, TestPassed, TestFailed, PositionDescription}
+import intent.core.{Expectation, ExpectationResult, TestPassed, TestFailed, PositionDescription, MapLike}
 import intent.macros.Position
 import intent.util.DelayedFuture
 import intent.core.expectations._
@@ -85,7 +84,7 @@ trait ExpectGivens with
   /**
    * Expect that a key-value tuple exists in the given map
    */
-  def [K, V](expect: Expect[Map[K, V] | MMap[K, V]]) toContain (expected: (K, V))
+  def [K, V](expect: Expect[MapLike[K, V]]) toContain (expected: (K, V))
     (given
        eqq: Eq[V],
        fmt: Formatter[V]
@@ -94,7 +93,7 @@ trait ExpectGivens with
   /**
    * Expect that multiple key-value tuple exists in the given map
    */
-  def [K, V](expect: Expect[Map[K, V] | MMap[K, V]]) toContainAllOf (expected: (K, V)*)
+  def [K, V](expect: Expect[MapLike[K, V]]) toContainAllOf (expected: (K, V)*)
   (given
      eqq: Eq[V],
      fmt: Formatter[V]

--- a/src/main/scala/intent/core/expect.scala
+++ b/src/main/scala/intent/core/expect.scala
@@ -84,7 +84,7 @@ trait ExpectGivens with
   /**
    * Expect that a key-value tuple exists in the given map
    */
-  def [K, V](expect: Expect[Map[K, V]]) toContain (expected: (K, V))
+  def [K, V](expect: Expect[Map[K, V]]) toContain (expected: (K, V)*)
     (given
        eqq: Eq[V],
        fmt: Formatter[V]

--- a/src/main/scala/intent/core/expect.scala
+++ b/src/main/scala/intent/core/expect.scala
@@ -87,7 +87,8 @@ trait ExpectGivens with
   def [K, V](expect: Expect[MapLike[K, V]]) toContain (expected: (K, V))
     (given
        eqq: Eq[V],
-       fmt: Formatter[V]
+       keyFmt: Formatter[K],
+       valueFmt: Formatter[V]
     ): Expectation = new MapContainExpectation(expect, Seq(expected))
 
   /**
@@ -96,7 +97,8 @@ trait ExpectGivens with
   def [K, V](expect: Expect[MapLike[K, V]]) toContainAllOf (expected: (K, V)*)
   (given
      eqq: Eq[V],
-     fmt: Formatter[V]
+     keyFmt: Formatter[K],
+     valueFmt: Formatter[V]
   ): Expectation = new MapContainExpectation(expect, expected)
 
   // Note: Not using IterableOnce here as it matches Option and we don't want that.

--- a/src/main/scala/intent/core/expect.scala
+++ b/src/main/scala/intent/core/expect.scala
@@ -4,6 +4,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Success, Failure}
 import scala.collection.IterableOnce
 import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.{Map  => MMap}
 import scala.language.implicitConversions
 import scala.util.matching.Regex
 import scala.reflect.ClassTag
@@ -84,7 +85,7 @@ trait ExpectGivens with
   /**
    * Expect that a key-value tuple exists in the given map
    */
-  def [K, V](expect: Expect[Map[K, V]]) toContain (expected: (K, V))
+  def [K, V](expect: Expect[Map[K, V] | MMap[K, V]]) toContain (expected: (K, V))
     (given
        eqq: Eq[V],
        fmt: Formatter[V]
@@ -93,7 +94,7 @@ trait ExpectGivens with
   /**
    * Expect that multiple key-value tuple exists in the given map
    */
-  def [K, V](expect: Expect[Map[K, V]]) toContainAllOf (expected: (K, V)*)
+  def [K, V](expect: Expect[Map[K, V] | MMap[K, V]]) toContainAllOf (expected: (K, V)*)
   (given
      eqq: Eq[V],
      fmt: Formatter[V]

--- a/src/main/scala/intent/core/expectations/contain.scala
+++ b/src/main/scala/intent/core/expectations/contain.scala
@@ -81,7 +81,8 @@ class ArrayContainExpectation[T](expect: Expect[Array[T]], expected: T)(
 class MapContainExpectation[K, V](expect: Expect[MapLike[K, V]], expected: Seq[Tuple2[K, V]])(
   given
     eqq: Eq[V],
-    fmt: Formatter[V]
+    keyFmt: Formatter[K],
+    valueFmt: Formatter[V],
 ) extends Expectation with
 
   def evaluate(): Future[ExpectationResult] =
@@ -109,8 +110,8 @@ class MapContainExpectation[K, V](expect: Expect[MapLike[K, V]], expected: Seq[T
         var message = s"Expected ${describeActualWithContext(actual)} to "
         if (expect.isNegated) message += "not "
         message += "contain:\n  "
-        message += failingKeys.map(p => s"${p._1} -> ${p._2}").mkString("\n  ")
-        message += failingValues.map(p => s"${p._1} -> ${p._2} but found ${p._1} -> ${p._3}").mkString("\n  ")
+        message += failingKeys.map(p => s"${keyFmt.format(p._1)} -> ${valueFmt.format(p._2)}").mkString("\n  ")
+        message += failingValues.map(p => s"${keyFmt.format(p._1)} -> ${valueFmt.format(p._2)} but found ${keyFmt.format(p._1)} -> ${valueFmt.format(p._3)}").mkString("\n  ")
         expect.fail(message)
 
   private def describeActualWithContext(actual: MapLike[K, V]): String = "Map(...)"

--- a/src/main/scala/intent/core/expectations/contain.scala
+++ b/src/main/scala/intent/core/expectations/contain.scala
@@ -76,3 +76,21 @@ class ArrayContainExpectation[T](expect: Expect[Array[T]], expected: T)(
   def evaluate(): Future[ExpectationResult] =
     val actual = expect.evaluate()
     evalToContain(actual, expected, expect, "Array")
+
+class MapContainExpectation[K, V](expect: Expect[Map[K, V]], expected: Tuple2[K, V])(
+  given
+    eqq: Eq[V],
+    fmt: Formatter[V] // TODO: Should there be a separate formatter maybe?
+) extends Expectation with
+
+  def evaluate(): Future[ExpectationResult] =
+    val actual = expect.evaluate()
+    val key = expected._1
+    Future.successful:
+      actual.get(key) match
+        case None =>
+          if !expect.isNegated then expect.fail(s"Key $key was not found in Map") // TODO: Add some context
+          expect.pass
+        case Some(v) =>
+          if expect.isNegated then expect.fail(s"Key $key was unexpectedly found in Map")
+          expect.pass

--- a/src/main/scala/intent/core/expectations/contain.scala
+++ b/src/main/scala/intent/core/expectations/contain.scala
@@ -1,9 +1,9 @@
 package intent.core.expectations
 
 import intent.core._
+import intent.core.MapLike
 import scala.concurrent.Future
 import scala.collection.mutable.ListBuffer
-import scala.collection.mutable.{ Map => MMap }
 import scala.Array
 
 private def evalToContain[T](actual: IterableOnce[T],
@@ -78,7 +78,7 @@ class ArrayContainExpectation[T](expect: Expect[Array[T]], expected: T)(
     val actual = expect.evaluate()
     evalToContain(actual, expected, expect, "Array")
 
-class MapContainExpectation[K, V](expect: Expect[Map[K, V] | MMap[K, V]], expected: Seq[Tuple2[K, V]])(
+class MapContainExpectation[K, V](expect: Expect[MapLike[K, V]], expected: Seq[Tuple2[K, V]])(
   given
     eqq: Eq[V],
     fmt: Formatter[V]
@@ -107,11 +107,10 @@ class MapContainExpectation[K, V](expect: Expect[Map[K, V] | MMap[K, V]], expect
         expect.pass
       else
         var message = s"Expected ${describeActualWithContext(actual)} to "
-        // var message = s"Expected Map(...) to "
         if (expect.isNegated) message += "not "
         message += "contain:\n  "
         message += failingKeys.map(p => s"${p._1} -> ${p._2}").mkString("\n  ")
         message += failingValues.map(p => s"${p._1} -> ${p._2} but found ${p._1} -> ${p._3}").mkString("\n  ")
         expect.fail(message)
 
-  private def describeActualWithContext(actual: Map[K, V] | MMap[K, V]): String = "Map(...)"
+  private def describeActualWithContext(actual: MapLike[K, V]): String = "Map(...)"

--- a/src/main/scala/intent/core/expectations/contain.scala
+++ b/src/main/scala/intent/core/expectations/contain.scala
@@ -106,6 +106,10 @@ class MapContainExpectation[K, V](expect: Expect[MapLike[K, V]], expected: Seq[T
     Future.successful:
       if failingKeys.isEmpty && failingValues.isEmpty then
         expect.pass
+      else if expect.isNegated && failingKeys.length < expected.length then
+        // If only some of the pairs were missing, the negated expect is fulfilled, i.e. actual does not, not.containAllOf
+        // This type of negation should be avoided in tests though, as the intention is not clear
+        expect.pass
       else
         var message = s"Expected ${describeActualWithContext(actual)} to "
         if (expect.isNegated) message += "not "

--- a/src/main/scala/intent/core/expectations/contain.scala
+++ b/src/main/scala/intent/core/expectations/contain.scala
@@ -93,11 +93,11 @@ class MapContainExpectation[K, V](expect: Expect[MapLike[K, V]], expected: Seq[T
       actual.get(expectedPair._1) match {
         case None if expect.isNegated =>
           () // OK = NOOP
-        case None if !expect.isNegated =>
+        case None =>
           failingKeys :+= expectedPair
         case Some(v) if expect.isNegated =>
           failingKeys :+= expectedPair
-        case Some(v) if !expect.isNegated   =>
+        case Some(v)   =>
           if !eqq.areEqual(v, expectedPair._2) then failingValues :+= (expectedPair._1, expectedPair._2, v)
       }
     }

--- a/src/main/scala/intent/core/expectations/contain.scala
+++ b/src/main/scala/intent/core/expectations/contain.scala
@@ -3,6 +3,7 @@ package intent.core.expectations
 import intent.core._
 import scala.concurrent.Future
 import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.{ Map => MMap }
 import scala.Array
 
 private def evalToContain[T](actual: IterableOnce[T],
@@ -77,7 +78,7 @@ class ArrayContainExpectation[T](expect: Expect[Array[T]], expected: T)(
     val actual = expect.evaluate()
     evalToContain(actual, expected, expect, "Array")
 
-class MapContainExpectation[K, V](expect: Expect[Map[K, V]], expected: Seq[Tuple2[K, V]])(
+class MapContainExpectation[K, V](expect: Expect[Map[K, V] | MMap[K, V]], expected: Seq[Tuple2[K, V]])(
   given
     eqq: Eq[V],
     fmt: Formatter[V]
@@ -106,10 +107,11 @@ class MapContainExpectation[K, V](expect: Expect[Map[K, V]], expected: Seq[Tuple
         expect.pass
       else
         var message = s"Expected ${describeActualWithContext(actual)} to "
+        // var message = s"Expected Map(...) to "
         if (expect.isNegated) message += "not "
         message += "contain:\n  "
         message += failingKeys.map(p => s"${p._1} -> ${p._2}").mkString("\n  ")
         message += failingValues.map(p => s"${p._1} -> ${p._2} but found ${p._1} -> ${p._3}").mkString("\n  ")
         expect.fail(message)
 
-  private def describeActualWithContext(actual: Map[K, V]): String = "Map(...)"
+  private def describeActualWithContext(actual: Map[K, V] | MMap[K, V]): String = "Map(...)"

--- a/src/test/scala/intent/matchers/ToContainAllOfTest.scala
+++ b/src/test/scala/intent/matchers/ToContainAllOfTest.scala
@@ -12,15 +12,15 @@ class ToContainAllOfTest extends TestSuite with Stateless with Meta with
             runExpectation(
               expect(Map("one" -> 1, "two" -> 2)).not.toContainAllOf("one" -> 1, "two" -> 2),
               """Expected Map(...) to not contain:
-              |  one -> 1
-              |  two -> 2""".stripMargin)
+              |  "one" -> 1
+              |  "two" -> 2""".stripMargin)
 
         "error is described properly" in:
           runExpectation(
             expect(Map("one" -> 11, "two" -> 22)).toContainAllOf("one" -> 1, "two" -> 2),
             """Expected Map(...) to contain:
-            |  one -> 1 but found one -> 11
-            |  two -> 2 but found two -> 22""".stripMargin)
+            |  "one" -> 1 but found "one" -> 11
+            |  "two" -> 2 but found "two" -> 22""".stripMargin)
 
         "with correct key and values":
           "should contain multiple elements" in:

--- a/src/test/scala/intent/matchers/ToContainAllOfTest.scala
+++ b/src/test/scala/intent/matchers/ToContainAllOfTest.scala
@@ -26,7 +26,12 @@ class ToContainAllOfTest extends TestSuite with Stateless with Meta with
           "should contain multiple elements" in:
             expect(Map("one" -> 1, "two" -> 2)).toContainAllOf("two" -> 2, "one" -> 1)
 
-      "for mutable map":
+      "for scala.collection.mutable.Map":
         "with correct key and values":
           "should contain multiple elements" in:
             expect(scala.collection.mutable.Map("one" -> 1, "two" -> 2)).toContainAllOf("two" -> 2, "one" -> 1)
+
+      "for scala.collection.immutable.Map":
+            "with correct key and values":
+              "should contain multiple elements" in:
+                expect(scala.collection.immutable.Map("one" -> 1, "two" -> 2)).toContainAllOf("two" -> 2, "one" -> 1)

--- a/src/test/scala/intent/matchers/ToContainAllOfTest.scala
+++ b/src/test/scala/intent/matchers/ToContainAllOfTest.scala
@@ -15,6 +15,16 @@ class ToContainAllOfTest extends TestSuite with Stateless with Meta with
               |  "one" -> 1
               |  "two" -> 2""".stripMargin)
 
+        "when partially matching":
+          "error is described properly" in:
+            runExpectation(
+              expect(Map("one" -> 1, "two" -> 2)).toContainAllOf("one" -> 1, "three" -> 3),
+              """Expected Map(...) to contain:
+              |  "three" -> 3""".stripMargin)
+          "and negating":
+            "should pass since Map is not missing both pairs" in:
+              expect(Map("one" -> 1, "two" -> 2)).not.toContainAllOf("one" -> 1, "three" -> 3)
+
         "error is described properly" in:
           runExpectation(
             expect(Map("one" -> 11, "two" -> 22)).toContainAllOf("one" -> 1, "two" -> 2),

--- a/src/test/scala/intent/matchers/ToContainAllOfTest.scala
+++ b/src/test/scala/intent/matchers/ToContainAllOfTest.scala
@@ -1,0 +1,27 @@
+package intent.matchers
+
+import intent.{Stateless, TestSuite}
+import intent.helpers.Meta
+
+class ToContainAllOfTest extends TestSuite with Stateless with Meta with
+  "toContainAllOf" focused:
+    "for Map":
+      "of String -> Int":
+        "when negated":
+          "error is described properly also for multiple elements" in:
+            runExpectation(
+              expect(Map("one" -> 1, "two" -> 2)).not.toContainAllOf("one" -> 1, "two" -> 2),
+              """Expected Map(...) to not contain:
+              |  one -> 1
+              |  two -> 2""".stripMargin)
+
+        "error is described properly" in:
+          runExpectation(
+            expect(Map("one" -> 11, "two" -> 22)).toContainAllOf("one" -> 1, "two" -> 2),
+            """Expected Map(...) to contain:
+            |  one -> 1 but found one -> 11
+            |  two -> 2 but found two -> 22""".stripMargin)
+
+        "with correct key and values":
+          "should contain multiple elements" in:
+            expect(Map("one" -> 1, "two" -> 2)).toContainAllOf("two" -> 2, "one" -> 1)

--- a/src/test/scala/intent/matchers/ToContainAllOfTest.scala
+++ b/src/test/scala/intent/matchers/ToContainAllOfTest.scala
@@ -25,3 +25,8 @@ class ToContainAllOfTest extends TestSuite with Stateless with Meta with
         "with correct key and values":
           "should contain multiple elements" in:
             expect(Map("one" -> 1, "two" -> 2)).toContainAllOf("two" -> 2, "one" -> 1)
+
+      "for mutable map":
+        "with correct key and values":
+          "should contain multiple elements" in:
+            expect(scala.collection.mutable.Map("one" -> 1, "two" -> 2)).toContainAllOf("two" -> 2, "one" -> 1)

--- a/src/test/scala/intent/matchers/ToContainAllOfTest.scala
+++ b/src/test/scala/intent/matchers/ToContainAllOfTest.scala
@@ -4,7 +4,7 @@ import intent.{Stateless, TestSuite}
 import intent.helpers.Meta
 
 class ToContainAllOfTest extends TestSuite with Stateless with Meta with
-  "toContainAllOf" focused:
+  "toContainAllOf":
     "for Map":
       "of String -> Int":
         "when negated":

--- a/src/test/scala/intent/matchers/ToContainTest.scala
+++ b/src/test/scala/intent/matchers/ToContainTest.scala
@@ -44,21 +44,21 @@ class ToContainTest extends TestSuite with Stateless with Meta with
             runExpectation(
               expect(Map("one" -> 1, "two" -> 2)).not.toContain("one" -> 1),
               """Expected Map(...) to not contain:
-              |  one -> 1""".stripMargin)
+              |  "one" -> 1""".stripMargin)
 
         "with invalid key":
           "error is described properly" in:
             runExpectation(
               expect(Map("one" -> 1, "two" -> 2)).toContain("three" -> 3),
                 """Expected Map(...) to contain:
-                |  three -> 3""".stripMargin)
+                |  "three" -> 3""".stripMargin)
 
         "with correct key but invalid value":
           "error is described properly" in:
           runExpectation(
             expect(Map("one" -> 1, "two" -> 2)).toContain("two" -> 3),
             """Expected Map(...) to contain:
-            |  two -> 3 but found two -> 2""".stripMargin)
+            |  "two" -> 3 but found "two" -> 2""".stripMargin)
 
         "with correct key and value":
           "should contain element" in:

--- a/src/test/scala/intent/matchers/ToContainTest.scala
+++ b/src/test/scala/intent/matchers/ToContainTest.scala
@@ -33,3 +33,8 @@ class ToContainTest extends TestSuite with Stateless with Meta with
         given cutoff: intent.core.ListCutoff = intent.core.ListCutoff(5)
         val list = LazyList.from(1)
         expect(list).not.toContain(10)
+
+    "for Map":
+      "of String -> Int":
+        "does not contain element" in expect(Map("one" -> 1, "two" -> 2)).not.toContain("three" -> 3)
+        "should contain element" in expect(Map("one" -> 1, "two" -> 2)).toContain("two" -> 2)

--- a/src/test/scala/intent/matchers/ToContainTest.scala
+++ b/src/test/scala/intent/matchers/ToContainTest.scala
@@ -63,3 +63,8 @@ class ToContainTest extends TestSuite with Stateless with Meta with
         "with correct key and value":
           "should contain element" in:
             expect(Map("one" -> 1, "two" -> 2)).toContain("two" -> 2)
+
+      "for mutable Map":
+        "with correct key and value":
+          "should contain element" in:
+            expect(scala.collection.mutable.Map("one" -> 1, "two" -> 2)).toContain("two" -> 2)

--- a/src/test/scala/intent/matchers/ToContainTest.scala
+++ b/src/test/scala/intent/matchers/ToContainTest.scala
@@ -64,7 +64,12 @@ class ToContainTest extends TestSuite with Stateless with Meta with
           "should contain element" in:
             expect(Map("one" -> 1, "two" -> 2)).toContain("two" -> 2)
 
-      "for mutable Map":
+      "for mutable scala.collection.mutable.Map":
         "with correct key and value":
           "should contain element" in:
             expect(scala.collection.mutable.Map("one" -> 1, "two" -> 2)).toContain("two" -> 2)
+
+      "for scala.collection.immutable.Map":
+        "with correct key and value":
+          "should contain element" in:
+            expect(scala.collection.immutable.Map("one" -> 1, "two" -> 2)).toContain("two" -> 2)

--- a/src/test/scala/intent/matchers/ToContainTest.scala
+++ b/src/test/scala/intent/matchers/ToContainTest.scala
@@ -46,13 +46,6 @@ class ToContainTest extends TestSuite with Stateless with Meta with
               """Expected Map(...) to not contain:
               |  one -> 1""".stripMargin)
 
-          "error is described properly also for multiple elements" in:
-            runExpectation(
-              expect(Map("one" -> 1, "two" -> 2)).not.toContain("one" -> 1, "two" -> 2),
-              """Expected Map(...) to not contain:
-              |  one -> 1
-              |  two -> 2""".stripMargin)
-
         "with invalid key":
           "error is described properly" in:
             runExpectation(
@@ -70,6 +63,3 @@ class ToContainTest extends TestSuite with Stateless with Meta with
         "with correct key and value":
           "should contain element" in:
             expect(Map("one" -> 1, "two" -> 2)).toContain("two" -> 2)
-
-        "should contain multiple elements" in:
-          expect(Map("one" -> 1, "two" -> 2)).toContain("two" -> 2, "one" -> 1)

--- a/src/test/scala/intent/matchers/ToContainTest.scala
+++ b/src/test/scala/intent/matchers/ToContainTest.scala
@@ -36,5 +36,40 @@ class ToContainTest extends TestSuite with Stateless with Meta with
 
     "for Map":
       "of String -> Int":
-        "does not contain element" in expect(Map("one" -> 1, "two" -> 2)).not.toContain("three" -> 3)
-        "should contain element" in expect(Map("one" -> 1, "two" -> 2)).toContain("two" -> 2)
+        "when negated":
+          "does not contain element" in:
+            expect(Map("one" -> 1, "two" -> 2)).not.toContain("three" -> 3)
+
+          "error is described properly" in:
+            runExpectation(
+              expect(Map("one" -> 1, "two" -> 2)).not.toContain("one" -> 1),
+              """Expected Map(...) to not contain:
+              |  one -> 1""".stripMargin)
+
+          "error is described properly also for multiple elements" in:
+            runExpectation(
+              expect(Map("one" -> 1, "two" -> 2)).not.toContain("one" -> 1, "two" -> 2),
+              """Expected Map(...) to not contain:
+              |  one -> 1
+              |  two -> 2""".stripMargin)
+
+        "with invalid key":
+          "error is described properly" in:
+            runExpectation(
+              expect(Map("one" -> 1, "two" -> 2)).toContain("three" -> 3),
+                """Expected Map(...) to contain:
+                |  three -> 3""".stripMargin)
+
+        "with correct key but invalid value":
+          "error is described properly" in:
+          runExpectation(
+            expect(Map("one" -> 1, "two" -> 2)).toContain("two" -> 3),
+            """Expected Map(...) to contain:
+            |  two -> 3 but found two -> 2""".stripMargin)
+
+        "with correct key and value":
+          "should contain element" in:
+            expect(Map("one" -> 1, "two" -> 2)).toContain("two" -> 2)
+
+        "should contain multiple elements" in:
+          expect(Map("one" -> 1, "two" -> 2)).toContain("two" -> 2, "one" -> 1)


### PR DESCRIPTION
Initial work to support `.toContain` and `.toContainAllOf` for Map.

@provegard, what do you think of the matcher style, and the output?

Still needed (although in separate PR's):

* ~~Support for mutable Map~~
* Matcher for only key(s)
* Equality matchers on complete Map

Part of #36
