### PR TITLE
Upgrade Dotty 0.22.0-RC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
-## Pending release
+## 0.5.0 (2020-02-06)
 
 * Add `.toContain` for `Map` objects
   See [toContain](docs/matchers.md#.toContain)
 
 * Add `.toContainAllOf` for `Map` objects
   See [toContain](docs/matchers.md#.toContainAllOf)
+
+* Upgrade to Dotty 0.22.0-RC1
 
 ## 0.4.0 (2019-12-21)
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ how to use Intent to write tests, see [User documentation](docs/index.md).
 Add Intent to your SBT project with the following lines to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.factor10" %% "intent" % "0.4.0",
+libraryDependencies += "com.factor10" %% "intent" % "0.5.0",
 testFrameworks += new TestFramework("intent.sbt.Framework")
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
-val dottyVersion = "0.21.0-RC1"
+val dottyVersion = "0.22.0-RC1"
 
 ThisBuild / name := "intent"
-ThisBuild / version := "0.4.0"
+ThisBuild / version := "0.5.0"
 ThisBuild / scalaVersion := dottyVersion
 ThisBuild / publishTo := sonatypePublishToBundle.value
 

--- a/src/main/scala/intent/core/equality.scala
+++ b/src/main/scala/intent/core/equality.scala
@@ -15,7 +15,7 @@ object DefaultDoubleFloatingPointPrecision extends FloatingPointPrecision[Double
 object DefaultFloatFloatingPointPrecision extends FloatingPointPrecision[Float] with
   def numberOfDecimals: Int = 6
 
-private def compareFPs[T : Numeric](a: T, b: T)(given prec: FloatingPointPrecision[T]): Boolean =
+private def compareFPs[T : Numeric](a: T, b: T)(using prec: FloatingPointPrecision[T]): Boolean =
   if a == b then
     return true
   val num = summon[Numeric[T]]
@@ -30,10 +30,10 @@ object IntEq extends Eq[Int] with
 object LongEq extends Eq[Long] with
   def areEqual(a: Long, b: Long): Boolean = a == b
 
-class DoubleEq(given prec: FloatingPointPrecision[Double]) extends Eq[Double] with
+class DoubleEq(using prec: FloatingPointPrecision[Double]) extends Eq[Double] with
   def areEqual(a: Double, b: Double): Boolean = compareFPs(a, b)
 
-class FloatEq(given prec: FloatingPointPrecision[Float]) extends Eq[Float] with
+class FloatEq(using prec: FloatingPointPrecision[Float]) extends Eq[Float] with
   def areEqual(a: Float, b: Float): Boolean = compareFPs(a, b)
 
 object BooleanEq extends Eq[Boolean] with
@@ -54,14 +54,14 @@ object AnyEq extends Eq[Any] with
 object NothingEq extends Eq[Nothing] with
   def areEqual(a: Nothing, b: Nothing): Boolean = a == b
 
-class OptionEq[TInner, T <: Option[TInner]](given innerEq: Eq[TInner]) extends Eq[T] with
+class OptionEq[TInner, T <: Option[TInner]](using innerEq: Eq[TInner]) extends Eq[T] with
   def areEqual(a: T, b: T): Boolean =
     (a, b) match
       case (Some(aa), Some(bb)) => innerEq.areEqual(aa, bb)
       case (None, None) => true
       case _ => false
 
-class TryEq[TInner, T <: Try[TInner]](given innerEq: Eq[TInner], throwableEq: Eq[Throwable]) extends Eq[T] with
+class TryEq[TInner, T <: Try[TInner]](using innerEq: Eq[TInner], throwableEq: Eq[Throwable]) extends Eq[T] with
   def areEqual(a: T, b: T): Boolean =
     (a, b) match
       case (Success(aa), Success(bb)) => innerEq.areEqual(aa, bb)
@@ -78,8 +78,8 @@ trait EqGivens with
   given Eq[Boolean] = BooleanEq
   given Eq[String] = StringEq
   given Eq[Char] = CharEq
-  given (given FloatingPointPrecision[Double]): Eq[Double] = DoubleEq()
-  given (given FloatingPointPrecision[Float]): Eq[Float] = FloatEq()
+  given (using FloatingPointPrecision[Double]): Eq[Double] = DoubleEq()
+  given (using FloatingPointPrecision[Float]): Eq[Float] = FloatEq()
   given throwableEq[T <: Throwable]: Eq[T] = ThrowableEq[T]
-  given optEq[TInner, T <: Option[TInner]](given Eq[TInner]): Eq[T] = OptionEq[TInner, T]
-  given tryEq[TInner, T <: Try[TInner]](given Eq[TInner]): Eq[T] = TryEq[TInner, T]
+  given optEq[TInner, T <: Option[TInner]](using Eq[TInner]): Eq[T] = OptionEq[TInner, T]
+  given tryEq[TInner, T <: Try[TInner]](using Eq[TInner]): Eq[T] = TryEq[TInner, T]

--- a/src/main/scala/intent/core/expect.scala
+++ b/src/main/scala/intent/core/expect.scala
@@ -22,7 +22,7 @@ import intent.core.expectations._
   */
 case class ListCutoff(maxItems: Int = 1000, printItems: Int = 5)
 
-class CompoundExpectation(inner: Seq[Expectation])(given ec: ExecutionContext) extends Expectation with
+class CompoundExpectation(inner: Seq[Expectation])(using ec: ExecutionContext) extends Expectation with
   def evaluate(): Future[ExpectationResult] =
     val innerFutures = inner.map(_.evaluate())
     Future.sequence(innerFutures).map { results =>
@@ -47,15 +47,15 @@ trait ExpectGivens with
 
   def [T](expect: Expect[T]) not: Expect[T] = expect.negate()
 
-  def [T](expect: Expect[T]) toEqual (expected: T)(given eqq: Eq[T], fmt: Formatter[T]): Expectation =
+  def [T](expect: Expect[T]) toEqual (expected: T)(using eqq: Eq[T], fmt: Formatter[T]): Expectation =
     new EqualExpectation(expect, expected)
 
   // toMatch is partial
-  def [T](expect: Expect[String]) toMatch (re: Regex)(given fmt: Formatter[String]): Expectation =
+  def [T](expect: Expect[String]) toMatch (re: Regex)(using fmt: Formatter[String]): Expectation =
     new MatchExpectation(expect, re)
 
   def [T](expect: Expect[Future[T]]) toCompleteWith (expected: T)
-     (given
+     (using
         eqq: Eq[T],
         fmt: Formatter[T],
         errFmt: Formatter[Throwable],
@@ -66,7 +66,7 @@ trait ExpectGivens with
 
   // We use ClassTag here to avoid "double definition error" wrt Expect[IterableOnce[T]]
   def [T : ClassTag](expect: Expect[Array[T]]) toContain (expected: T)
-     (given
+     (using
         eqq: Eq[T],
         fmt: Formatter[T],
         cutoff: ListCutoff
@@ -74,7 +74,7 @@ trait ExpectGivens with
     new ArrayContainExpectation(expect, expected)
 
   def [T](expect: Expect[IterableOnce[T]]) toContain (expected: T)
-     (given
+     (using
         eqq: Eq[T],
         fmt: Formatter[T],
         cutoff: ListCutoff
@@ -85,7 +85,7 @@ trait ExpectGivens with
    * Expect that a key-value tuple exists in the given map
    */
   def [K, V](expect: Expect[MapLike[K, V]]) toContain (expected: (K, V))
-    (given
+    (using
        eqq: Eq[V],
        keyFmt: Formatter[K],
        valueFmt: Formatter[V]
@@ -95,15 +95,15 @@ trait ExpectGivens with
    * Expect that multiple key-value tuple exists in the given map
    */
   def [K, V](expect: Expect[MapLike[K, V]]) toContainAllOf (expected: (K, V)*)
-  (given
-     eqq: Eq[V],
-     keyFmt: Formatter[K],
-     valueFmt: Formatter[V]
-  ): Expectation = new MapContainExpectation(expect, expected)
+    (using
+      eqq: Eq[V],
+      keyFmt: Formatter[K],
+      valueFmt: Formatter[V]
+    ): Expectation = new MapContainExpectation(expect, expected)
 
   // Note: Not using IterableOnce here as it matches Option and we don't want that.
   def [T](expect: Expect[Iterable[T]]) toEqual (expected: Iterable[T])
-     (given
+     (using
         eqq: Eq[T],
         fmt: Formatter[T]
       ): Expectation =
@@ -111,7 +111,7 @@ trait ExpectGivens with
 
   // We use ClassTag here to avoid "double definition error" wrt Expect[Iterable[T]]
   def [T : ClassTag](expect: Expect[Array[T]]) toEqual (expected: Iterable[T])
-     (given
+     (using
         eqq: Eq[T],
         fmt: Formatter[T]
       ): Expectation =
@@ -120,19 +120,19 @@ trait ExpectGivens with
   /**
    * (1, 2, 3) toHaveLength 3
    */
-  def [T](expect: Expect[IterableOnce[T]]) toHaveLength (expected: Int)(given ec: ExecutionContext): Expectation =
+  def [T](expect: Expect[IterableOnce[T]]) toHaveLength (expected: Int)(using ec: ExecutionContext): Expectation =
     new LengthExpectation(expect, expected)
 
   // toThrow with only exception type
-  def [TEx : ClassTag](expect: Expect[_]) toThrow ()(given fmt: Formatter[String]): Expectation =
+  def [TEx : ClassTag](expect: Expect[_]) toThrow ()(using fmt: Formatter[String]): Expectation =
     new ThrowExpectation[TEx](expect, AnyExpectedMessage)
 
   // toThrow with exception type + message (string, so full match)
-  def [TEx : ClassTag](expect: Expect[_]) toThrow (expectedMessage: String)(given fmt: Formatter[String]): Expectation =
+  def [TEx : ClassTag](expect: Expect[_]) toThrow (expectedMessage: String)(using fmt: Formatter[String]): Expectation =
     new ThrowExpectation[TEx](expect, ExactExpectedMessage(expectedMessage))
 
     // toThrow with exception type + regexp (partial match, like toMatch)
-  def [TEx : ClassTag](expect: Expect[_]) toThrow (re: Regex)(given fmt: Formatter[String]): Expectation =
+  def [TEx : ClassTag](expect: Expect[_]) toThrow (re: Regex)(using fmt: Formatter[String]): Expectation =
     new ThrowExpectation[TEx](expect, RegexExpectedMessage(re))
 
   // TODO:

--- a/src/main/scala/intent/core/expectations/contain.scala
+++ b/src/main/scala/intent/core/expectations/contain.scala
@@ -10,7 +10,7 @@ private def evalToContain[T](actual: IterableOnce[T],
                               expected: T,
                               expect: Expect[_],
                               listTypeName: String)
-   (given
+   (using
       eqq: Eq[T],
       fmt: Formatter[T],
       cutoff: ListCutoff
@@ -57,7 +57,7 @@ private def evalToContain[T](actual: IterableOnce[T],
   Future.successful(r)
 
 class IterableContainExpectation[T](expect: Expect[IterableOnce[T]], expected: T)(
-  given
+  using
     eqq: Eq[T],
     fmt: Formatter[T],
     cutoff: ListCutoff
@@ -68,7 +68,7 @@ class IterableContainExpectation[T](expect: Expect[IterableOnce[T]], expected: T
     evalToContain(actual, expected, expect, listTypeName(actual))
 
 class ArrayContainExpectation[T](expect: Expect[Array[T]], expected: T)(
-  given
+  using
     eqq: Eq[T],
     fmt: Formatter[T],
     cutoff: ListCutoff
@@ -79,7 +79,7 @@ class ArrayContainExpectation[T](expect: Expect[Array[T]], expected: T)(
     evalToContain(actual, expected, expect, "Array")
 
 class MapContainExpectation[K, V](expect: Expect[MapLike[K, V]], expected: Seq[Tuple2[K, V]])(
-  given
+  using
     eqq: Eq[V],
     keyFmt: Formatter[K],
     valueFmt: Formatter[V],

--- a/src/main/scala/intent/core/expectations/equal.scala
+++ b/src/main/scala/intent/core/expectations/equal.scala
@@ -10,7 +10,7 @@ private def evalToEqual[T](actual: Iterable[T],
                             expect: Expect[_],
                             actualListTypeName: String,
                             expectedListTypeName: String)
-   (given
+   (using
       eqq: Eq[T],
       fmt: Formatter[T]
     ): Future[ExpectationResult] =
@@ -64,7 +64,7 @@ private def evalToEqual[T](actual: Iterable[T],
   Future.successful(r)
 
 class EqualExpectation[T](expect: Expect[T], expected: T)(
-  given eqq: Eq[T], fmt: Formatter[T]
+  using eqq: Eq[T], fmt: Formatter[T]
 ) extends Expectation with
 
   def evaluate(): Future[ExpectationResult] =
@@ -86,7 +86,7 @@ class EqualExpectation[T](expect: Expect[T], expected: T)(
     Future.successful(r)
 
 class IterableEqualExpectation[T](expect: Expect[Iterable[T]], expected: Iterable[T])(
-  given eqq: Eq[T], fmt: Formatter[T]
+  using eqq: Eq[T], fmt: Formatter[T]
 ) extends Expectation with
 
   def evaluate(): Future[ExpectationResult] =
@@ -95,7 +95,7 @@ class IterableEqualExpectation[T](expect: Expect[Iterable[T]], expected: Iterabl
 
 
 class ArrayEqualExpectation[T](expect: Expect[Array[T]], expected: Iterable[T])(
-  given eqq: Eq[T], fmt: Formatter[T]
+  using eqq: Eq[T], fmt: Formatter[T]
 ) extends Expectation with
 
   def evaluate(): Future[ExpectationResult] =

--- a/src/main/scala/intent/core/expectations/future.scala
+++ b/src/main/scala/intent/core/expectations/future.scala
@@ -7,7 +7,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Success, Failure}
 
 class ToCompleteWithExpectation[T](expect: Expect[Future[T]], expected: T)(
-  given
+  using
     eqq: Eq[T],
     fmt: Formatter[T],
     errFmt: Formatter[Throwable],

--- a/src/main/scala/intent/core/expectations/match.scala
+++ b/src/main/scala/intent/core/expectations/match.scala
@@ -5,7 +5,7 @@ import scala.concurrent.Future
 import scala.util.matching.Regex
 
 class MatchExpectation[T](expect: Expect[String], re: Regex)(
-  given fmt: Formatter[String]
+  using fmt: Formatter[String]
 ) extends Expectation with
   def evaluate(): Future[ExpectationResult] =
     val actual = expect.evaluate()

--- a/src/main/scala/intent/core/expectations/throw.scala
+++ b/src/main/scala/intent/core/expectations/throw.scala
@@ -14,7 +14,7 @@ object AnyExpectedMessage extends ExpectedMessage with
   def matches(msg: String) = true
   def describe() = ""
 
-class ExactExpectedMessage(expected: String)(given stringFmt: Formatter[String]) extends ExpectedMessage with
+class ExactExpectedMessage(expected: String)(using stringFmt: Formatter[String]) extends ExpectedMessage with
   def matches(msg: String) = msg == expected
   def describe() = s" with message ${stringFmt.format(expected)}"
 
@@ -27,7 +27,7 @@ private case class ExceptionMatch(typeOk: Boolean, messageOk: Boolean) with
     val ok = typeOk && messageOk
     if isNegated then !ok else ok
 
-class ThrowExpectation[TEx : ClassTag](expect: Expect[_], expectedMessage: ExpectedMessage)(given stringFmt: Formatter[String]) extends Expectation with
+class ThrowExpectation[TEx : ClassTag](expect: Expect[_], expectedMessage: ExpectedMessage)(using stringFmt: Formatter[String]) extends Expectation with
   def evaluate(): Future[ExpectationResult] =
     val expectedClass = implicitly[ClassTag[TEx]].runtimeClass
 

--- a/src/main/scala/intent/core/formatters.scala
+++ b/src/main/scala/intent/core/formatters.scala
@@ -32,12 +32,12 @@ class ThrowableFmt[T <: Throwable] extends Formatter[T] with
     // TODO: stack trace??
     s"${t.getClass.getName}: ${t.getMessage}"
 
-class OptionFmt[TInner, T <: Option[TInner]](given innerFmt: Formatter[TInner]) extends Formatter[T] with
+class OptionFmt[TInner, T <: Option[TInner]](using innerFmt: Formatter[TInner]) extends Formatter[T] with
   def format(value: T): String = value match
     case Some(x) => s"Some(${innerFmt.format(x)})"
     case None => "None"
 
-class TryFmt[TInner, T <: Try[TInner]](given innerFmt: Formatter[TInner], throwableFmt: Formatter[Throwable]) extends Formatter[T] with
+class TryFmt[TInner, T <: Try[TInner]](using innerFmt: Formatter[TInner], throwableFmt: Formatter[Throwable]) extends Formatter[T] with
   def format(value: T): String = value match
     case Success(x) => s"Success(${innerFmt.format(x)})"
     case Failure(t) => s"Failure(${throwableFmt.format(t)})"
@@ -52,5 +52,5 @@ trait FormatterGivens with
   given Formatter[Double] = DoubleFmt
   given Formatter[Float] = FloatFmt
 
-  given optFmt[TInner, T <: Option[TInner]](given Formatter[TInner]): Formatter[T] = OptionFmt[TInner, T]
-  given tryFmt[TInner, T <: Try[TInner]](given Formatter[TInner]): Formatter[T] = TryFmt[TInner, T]
+  given optFmt[TInner, T <: Option[TInner]](using Formatter[TInner]): Formatter[T] = OptionFmt[TInner, T]
+  given tryFmt[TInner, T <: Try[TInner]](using Formatter[TInner]): Formatter[T] = TryFmt[TInner, T]

--- a/src/main/scala/intent/runner/TestSuiteRunner.scala
+++ b/src/main/scala/intent/runner/TestSuiteRunner.scala
@@ -57,7 +57,7 @@ class TestSuiteRunner(classLoader: ClassLoader) with
    * Until the full suite is executed a subscriber can be given to receive events during the test-run. A custom
    * subscriber is also recommended if more details than the successful result is needed.
    */
-  def runSuite(className: String, eventSubscriber: Option[Subscriber[TestCaseResult]] = None)(given ec: ExecutionContext): Future[Either[TestSuiteError, TestSuiteResult]] =
+  def runSuite(className: String, eventSubscriber: Option[Subscriber[TestCaseResult]] = None)(using ec: ExecutionContext): Future[Either[TestSuiteError, TestSuiteResult]] =
     instantiateSuite(className) match
       case Success(instance) => runTestsForSuite(instance, eventSubscriber).map(res => Right(res))
       case Failure(ex: Throwable) => Future.successful(Left(TestSuiteError(ex)))
@@ -70,7 +70,7 @@ class TestSuiteRunner(classLoader: ClassLoader) with
       case Success(instance) => Right(instance)
       case Failure(ex: Throwable) => Left(TestSuiteError(ex))
 
-  private def runTestsForSuite(suite: IntentStructure, eventSubscriber: Option[Subscriber[TestCaseResult]])(given ec: ExecutionContext): Future[TestSuiteResult] =
+  private def runTestsForSuite(suite: IntentStructure, eventSubscriber: Option[Subscriber[TestCaseResult]])(using ec: ExecutionContext): Future[TestSuiteResult] =
     // TODO: We should measure Suite time as well. Might be good to find expensive setup or scheduling problems.
     val futureTestResults = suite.allTestCases.map(tc =>
       eventSubscriber match {

--- a/src/main/scala/intent/sbt/Runner.scala
+++ b/src/main/scala/intent/sbt/Runner.scala
@@ -90,7 +90,7 @@ class SbtTask(td: TaskDef, suit: IntentStructure, runner: TestSuiteRunner, focus
     // Hmm, do we need really to block here? Does SBT come with something included to be async
     Await.result(executeSuite(handler, loggers), Duration.Inf)
 
-  private def executeSuite(handler: EventHandler, loggers: Array[Logger])(given ec: ExecutionContext): Future[Array[Task]] =
+  private def executeSuite(handler: EventHandler, loggers: Array[Logger])(using ec: ExecutionContext): Future[Array[Task]] =
     object lock
     val eventSubscriber = new Subscriber[TestCaseResult]:
       override def onNext(event: TestCaseResult): Unit =

--- a/src/main/scala/intent/util/futures.scala
+++ b/src/main/scala/intent/util/futures.scala
@@ -14,7 +14,7 @@ trait DelayedFuture[T] extends Future[T] with
 object DelayedFuture with
   private val timer = new Timer
 
-  private def makeTask[T](body: => T)(schedule: TimerTask => Unit)(given ctx: ExecutionContext): Future[T] =
+  private def makeTask[T](body: => T)(schedule: TimerTask => Unit)(using ctx: ExecutionContext): Future[T] =
     val prom = Promise[T]()
     schedule(
       new TimerTask {
@@ -27,7 +27,7 @@ object DelayedFuture with
     )
     prom.future
 
-  def apply[T](duration: Duration)(body: => T)(given ctx: ExecutionContext): DelayedFuture[T] =
+  def apply[T](duration: Duration)(body: => T)(using ctx: ExecutionContext): DelayedFuture[T] =
     val isCancelled = new AtomicBoolean(false)
     val f = makeTask({
       if (!isCancelled.get()) body else null.asInstanceOf[T]

--- a/src/test/scala/intent/formatters/FormatTest.scala
+++ b/src/test/scala/intent/formatters/FormatTest.scala
@@ -20,5 +20,5 @@ class FormatTest extends TestSuite with Stateless with
       val t = RuntimeException("oops")
       expect(format(t)).toEqual("java.lang.RuntimeException: oops")
 
-  def format[T](x: T)(given fmt: core.Formatter[T]): String =
+  def format[T](x: T)(using fmt: core.Formatter[T]): String =
     fmt.format(x)

--- a/src/test/scala/intent/helpers/Meta.scala
+++ b/src/test/scala/intent/helpers/Meta.scala
@@ -6,7 +6,7 @@ import java.util.regex.Pattern
 
 trait Meta with
   self: TestLanguage with TestSupport =>
-    def runExpectation(e: => Expectation, expected: String)(given ExecutionContext): Expectation =
+    def runExpectation(e: => Expectation, expected: String)(using ExecutionContext): Expectation =
       new Expectation:
         def evaluate(): Future[ExpectationResult] =
           e.evaluate().flatMap:
@@ -18,7 +18,7 @@ trait Meta with
             case TestIgnored()  => Future.successful(TestFailed("Expected a test failure", None))
             case t: TestError   => Future.successful(t)
 
-    def runExpectation(e: => Expectation, exMatcher: PartialFunction[Throwable, Boolean])(given ExecutionContext): Expectation =
+    def runExpectation(e: => Expectation, exMatcher: PartialFunction[Throwable, Boolean])(using ExecutionContext): Expectation =
       new Expectation:
         def evaluate(): Future[ExpectationResult] =
           e.evaluate().flatMap:

--- a/src/test/scala/intent/helpers/TestSuiteRunnerTester.scala
+++ b/src/test/scala/intent/helpers/TestSuiteRunnerTester.scala
@@ -7,7 +7,7 @@ import intent.runner.{TestSuiteRunner, TestSuiteError, TestSuiteResult}
 /**
 * Supports running a test suite and checking the result.
 */
-trait TestSuiteRunnerTester(given ec: ExecutionContext) extends Subscriber[TestCaseResult] with
+trait TestSuiteRunnerTester(using ec: ExecutionContext) extends Subscriber[TestCaseResult] with
 
   def suiteClassName: String
 

--- a/src/test/scala/intent/runner/FocusedTest.scala
+++ b/src/test/scala/intent/runner/FocusedTest.scala
@@ -54,7 +54,7 @@ case class FocusedTestCase(
   suiteClassName: String = null,
   expectedSuccessful:Int = 0,
   expectedIgnored:Int = 0,
-  focused: Boolean = false)(given ec: ExecutionContext) extends TestSuiteRunnerTester
+  focused: Boolean = false)(using ec: ExecutionContext) extends TestSuiteRunnerTester
 
 class NestedFocusedStatelessTestSuite extends Stateless with
   "some suite" focused:

--- a/src/test/scala/intent/runner/TestSuiteRunnerTest.scala
+++ b/src/test/scala/intent/runner/TestSuiteRunnerTest.scala
@@ -152,7 +152,7 @@ class TestSuiteRunnerTest extends TestSuite with State[TestSuiteTestCase] with
 /**
  * Wraps a runner for a specific test suite
  */
-case class TestSuiteTestCase(suiteClassName: String = null)(given ec: ExecutionContext) extends TestSuiteRunnerTester with
+case class TestSuiteTestCase(suiteClassName: String = null)(using ec: ExecutionContext) extends TestSuiteRunnerTester with
 
   def emptyTestSuite = TestSuiteTestCase("intent.testdata.EmtpyTestSuite")
   def invalidTestSuiteClass = TestSuiteTestCase("foo.Bar")

--- a/src/test/scala/intent/styles/AsyncTest.scala
+++ b/src/test/scala/intent/styles/AsyncTest.scala
@@ -35,6 +35,6 @@ class AsyncStateTest extends TestSuite with AsyncState[MyAsyncState] with Meta w
       "sees the appropriate state" in:
         state => expect(state.s).toEqual("Hello async world")
 
-case class MyAsyncState(s: String)(given ExecutionContext) with
+case class MyAsyncState(s: String)(using ExecutionContext) with
   def map(s2: String) = copy(s = s + s2)
   def asyncMap(s2: String) = Future { copy(s = s + s2) }


### PR DESCRIPTION
Upgrade to use version 0.22.0-RC1 release of Dotty (released today!).

No changes was required (all tests green), but there are two new features introduced in 0.22 that I opted in on.

* Grouping of extension methods (less code and cohesion)
* Use `using` instead of previous `given` for implicits context parameters

I think the new syntax for context parameters is a good change, but might cause confusion with our use of `using` following a test context. At a conceptual level they are, somehow, both correct (both deal with using a context) - but a change on our side might still be needed? If so, any thoughts on new name?

Details at https://dotty.epfl.ch/blog/2020/02/05/22nd-dotty-milestone-release.html